### PR TITLE
[Fix] 스프링 부트 버전과 springdoc-openapi 라이브러리 버전 충돌 이슈 - fix/ddd-8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     implementation 'org.flywaydb:flyway-database-postgresql'
 
     // Swagger/OpenAPI
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'


### PR DESCRIPTION
# 요약

⏺ Spring Boot 3.5.5에서 ControllerAdviceBean 클래스의 생성자가 변경되었는데,
   SpringDoc OpenAPI 2.2.0이 이전 버전의 생성자를 호출하려고 해서 발생한
  문제입니다.

  구체적인 원인:

  1. Spring Boot 3.5.x 변경사항: Spring Boot 3.5.x에서 ControllerAdviceBean
  클래스의 생성자 시그니처가 변경됨
    - 이전: ControllerAdviceBean(Object bean)
    - 변경 후: 매개변수나 구현 방식이 달라짐
    
  2. SpringDoc 2.2.0의 문제:
    - GenericResponseService.java:700에서 ControllerAdviceBean을 생성할 때
  이전 버전의 생성자를 호출
    - Spring Boot 3.5.x와 호환되지 않는 코드 사용
    
  3. 에러 발생 시점:
    - /v3/api-docs 엔드포인트 접근 시 (Swagger UI가 OpenAPI 문서를 생성하려
  할 때)
    - SpringDoc이 컨트롤러 어드바이스 정보를 수집하는 과정에서 발생

  해결 방안 2.2.0 -> 2.7.0으로 버전 업그레이드
  SpringDoc OpenAPI 2.7.0은 Spring Boot 3.5.x의 변경된 API와 호환되도록
  업데이트되어 있어서 이 문제를 해결합니다.

# 연관 이슈 및 Close 할 이슈 작성

#8 

close #8 

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?