### PR TITLE
[Feature] 게시물(Post) API 기본 CRUD 기능 개발 - feature/ddd-10

### DIFF
--- a/src/main/java/com/example/petner/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/petner/domain/post/controller/PostController.java
@@ -1,0 +1,91 @@
+package com.example.petner.domain.post.controller;
+
+import com.example.petner.domain.post.dto.request.PostCreateRequest;
+import com.example.petner.domain.post.dto.request.PostUpdateRequest;
+import com.example.petner.domain.post.dto.response.PostResponse;
+import com.example.petner.domain.post.dto.response.PostSummaryResponse;
+import com.example.petner.domain.post.service.PostService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/api/v1/posts")
+@RequiredArgsConstructor
+@Tag(name = "게시물 (Posts)", description = "게시물 관련 API")
+public class PostController {
+
+    private final PostService postService;
+
+    @PostMapping
+    @Operation(summary = "게시물 생성", description = "새로운 게시물을 생성합니다.")
+    @ApiResponse(responseCode = "201", description = "게시물 생성 성공")
+    public ResponseEntity<PostResponse> createPost(@Valid @RequestBody PostCreateRequest request) {
+        // TODO: 추후 인증 기능이 구현되면, 현재 로그인한 사용자의 ID를 가져와서 사용해야 합니다.
+        Long currentMemberId = 1L;
+        PostResponse response = postService.createPost(currentMemberId, request);
+
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(response.getPostId())
+                .toUri();
+
+        return ResponseEntity.created(location).body(response);
+    }
+
+    @GetMapping("/{postId}")
+    @Operation(summary = "게시물 상세 조회", description = "특정 게시물 하나를 상세 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "게시물 조회 성공")
+    public ResponseEntity<PostResponse> getPost(@PathVariable Long postId) {
+        PostResponse response = postService.getPost(postId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    @Operation(summary = "게시물 목록 조회", description = "전체 게시물 목록을 페이징하여 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "게시물 목록 조회 성공")
+    public ResponseEntity<Page<PostSummaryResponse>> getPosts(
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기", example = "10") @RequestParam(defaultValue = "10") int size,
+            @Parameter(description = "정렬 방식 (예: createdAt,desc)", example = "createdAt,desc") @RequestParam(defaultValue = "createdAt,desc") String sort) {
+
+        String[] sortParams = sort.split(",");
+        Sort.Direction direction = sortParams.length > 1 && "asc".equalsIgnoreCase(sortParams[1])
+            ? Sort.Direction.ASC : Sort.Direction.DESC;
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortParams[0]));
+        Page<PostSummaryResponse> response = postService.getPosts(pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/{postId}")
+    @Operation(summary = "게시물 수정", description = "특정 게시물을 수정합니다.")
+    @ApiResponse(responseCode = "200", description = "게시물 수정 성공")
+    public ResponseEntity<PostResponse> updatePost(@PathVariable Long postId, @Valid @RequestBody PostUpdateRequest request) {
+        // TODO: 추후 인증 기능이 구현되면, 게시물 작성자와 현재 로그인한 사용자가 동일한지 확인해야 합니다.
+        PostResponse response = postService.updatePost(postId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{postId}")
+    @Operation(summary = "게시물 삭제", description = "특정 게시물을 삭제합니다.")
+    @ApiResponse(responseCode = "200", description = "게시물 삭제 성공")
+    public ResponseEntity<String> deletePost(@PathVariable Long postId) {
+        // TODO: 추후 인증 기능이 구현되면, 게시물 작성자와 현재 로그인한 사용자가 동일한지 확인해야 합니다.
+        postService.deletePost(postId);
+        return ResponseEntity.ok("게시물이 성공적으로 삭제되었습니다.");
+    }
+}

--- a/src/main/java/com/example/petner/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/example/petner/domain/post/dto/request/PostCreateRequest.java
@@ -1,0 +1,29 @@
+package com.example.petner.domain.post.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Schema(description = "게시물 생성 요청")
+public class PostCreateRequest {
+
+    @Schema(description = "게시물 제목", example = "첫 번째 게시물", maxLength = 200)
+    @NotBlank(message = "게시물 제목은 비워둘 수 없습니다.")
+    @Size(max = 200, message = "제목은 200자를 초과할 수 없습니다.")
+    private String title;
+
+    @Schema(description = "게시물 내용", example = "안녕하세요! 첫 번째 게시물입니다.")
+    @NotBlank(message = "게시물 내용은 비워둘 수 없습니다.")
+    private String content;
+
+    @Schema(description = "썸네일 이미지 URL", example = "https://example.com/image.jpg", maxLength = 500)
+    @Size(max = 500, message = "썸네일 이미지 URL은 500자를 초과할 수 없습니다.")
+    private String thumbImageUrl;
+}

--- a/src/main/java/com/example/petner/domain/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/com/example/petner/domain/post/dto/request/PostUpdateRequest.java
@@ -1,0 +1,29 @@
+package com.example.petner.domain.post.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Schema(description = "게시물 수정 요청")
+public class PostUpdateRequest {
+
+    @Schema(description = "게시물 제목", example = "수정된 게시물", maxLength = 200)
+    @NotBlank(message = "게시물 제목은 비워둘 수 없습니다.")
+    @Size(max = 200, message = "제목은 200자를 초과할 수 없습니다.")
+    private String title;
+
+    @Schema(description = "게시물 내용", example = "수정된 내용입니다.")
+    @NotBlank(message = "게시물 내용은 비워둘 수 없습니다.")
+    private String content;
+
+    @Schema(description = "썸네일 이미지 URL", example = "https://example.com/updated-image.jpg", maxLength = 500)
+    @Size(max = 500, message = "썸네일 이미지 URL은 500자를 초과할 수 없습니다.")
+    private String thumbImageUrl;
+}

--- a/src/main/java/com/example/petner/domain/post/dto/response/PostResponse.java
+++ b/src/main/java/com/example/petner/domain/post/dto/response/PostResponse.java
@@ -1,0 +1,30 @@
+package com.example.petner.domain.post.dto.response;
+
+import com.example.petner.domain.post.entity.Post;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class PostResponse {
+
+    private final Long postId;
+    private final String title;
+    private final String content;
+    private final String thumbImageUrl;
+    private final String authorNickname;
+    private final int viewCount;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public PostResponse(Post post) {
+        this.postId = post.getPostId();
+        this.title = post.getTitle();
+        this.content = post.getContent();
+        this.thumbImageUrl = post.getThumbImageUrl();
+        this.authorNickname = post.getAuthor().getNickname();
+        this.viewCount = post.getViewCount();
+        this.createdAt = post.getCreatedAt();
+        this.updatedAt = post.getUpdatedAt();
+    }
+}

--- a/src/main/java/com/example/petner/domain/post/dto/response/PostSummaryResponse.java
+++ b/src/main/java/com/example/petner/domain/post/dto/response/PostSummaryResponse.java
@@ -1,0 +1,26 @@
+package com.example.petner.domain.post.dto.response;
+
+import com.example.petner.domain.post.entity.Post;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class PostSummaryResponse {
+
+    private final Long postId;
+    private final String title;
+    private final String thumbImageUrl;
+    private final String authorNickname;
+    private final int viewCount;
+    private final LocalDateTime createdAt;
+
+    public PostSummaryResponse(Post post) {
+        this.postId = post.getPostId();
+        this.title = post.getTitle();
+        this.thumbImageUrl = post.getThumbImageUrl();
+        this.authorNickname = post.getAuthor().getNickname();
+        this.viewCount = post.getViewCount();
+        this.createdAt = post.getCreatedAt();
+    }
+}

--- a/src/main/java/com/example/petner/domain/post/entity/Post.java
+++ b/src/main/java/com/example/petner/domain/post/entity/Post.java
@@ -58,4 +58,10 @@ public class Post {
     public void increaseViewCount() {
         this.viewCount++;
     }
+
+    public void update(String title, String content, String thumbImageUrl) {
+        this.title = title;
+        this.content = content;
+        this.thumbImageUrl = thumbImageUrl;
+    }
 }

--- a/src/main/java/com/example/petner/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/example/petner/domain/post/repository/PostRepository.java
@@ -23,4 +23,17 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("SELECT p FROM Post p ORDER BY p.viewCount DESC")
     Page<Post> findAllOrderByViewCountDesc(Pageable pageable);
+
+    /**
+     * 전체 게시물 목록을 페이징하여 조회합니다.
+     * N+1 문제 해결을 위해 Fetch Join을 사용합니다.
+     * 페이징과 Fetch Join을 함께 사용할 때는 정확한 전체 개수 계산을 위해 countQuery를 분리하는 것이 좋습니다.
+     * ORDER BY 절을 제거하여 Pageable의 Sort가 적용되도록 합니다.
+     */
+    @Query(value = "SELECT p FROM Post p JOIN FETCH p.author",
+            countQuery = "SELECT count(p) FROM Post p")
+    Page<Post> findAllWithAuthor(Pageable pageable);
+
+    @Query("SELECT p FROM Post p JOIN FETCH p.author WHERE p.postId = :postId")
+    java.util.Optional<Post> findByIdWithAuthor(@Param("postId") Long postId);
 }

--- a/src/main/java/com/example/petner/domain/post/service/PostService.java
+++ b/src/main/java/com/example/petner/domain/post/service/PostService.java
@@ -1,0 +1,78 @@
+package com.example.petner.domain.post.service;
+
+import com.example.petner.domain.member.entity.Member;
+import com.example.petner.domain.member.repository.MemberRepository;
+import com.example.petner.domain.post.dto.request.PostCreateRequest;
+import com.example.petner.domain.post.dto.response.PostResponse;
+import com.example.petner.domain.post.dto.response.PostSummaryResponse;
+import com.example.petner.domain.post.dto.request.PostUpdateRequest;
+import com.example.petner.domain.post.repository.PostRepository;
+import com.example.petner.domain.post.entity.Post;
+import com.example.petner.global.exception.ErrorCode;
+import com.example.petner.global.exception.customException.MemberException;
+import com.example.petner.global.exception.customException.PostException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public PostResponse createPost(Long authorId, PostCreateRequest request) {
+        Member author = memberRepository.findById(authorId)
+                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+
+        Post post = Post.builder()
+                .title(request.getTitle())
+                .content(request.getContent())
+                .thumbImageUrl(request.getThumbImageUrl())
+                .author(author)
+                .build();
+
+        Post savedPost = postRepository.save(post);
+        return new PostResponse(savedPost);
+    }
+
+    @Transactional
+    public PostResponse getPost(Long postId) {
+        Post post = postRepository.findByIdWithAuthor(postId)
+                .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
+        post.increaseViewCount();
+        return new PostResponse(post);
+    }
+
+    public Page<PostSummaryResponse> getPosts(Pageable pageable) {
+        return postRepository.findAllWithAuthor(pageable)
+                .map(PostSummaryResponse::new);
+    }
+
+    @Transactional
+    public PostResponse updatePost(Long postId, PostUpdateRequest request) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
+
+        // TODO: Implement author check for update permission
+
+        post.update(request.getTitle(), request.getContent(), request.getThumbImageUrl());
+
+        return new PostResponse(post);
+    }
+
+    @Transactional
+    public void deletePost(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
+
+        // TODO: Implement author check for delete permission
+
+        postRepository.delete(post);
+    }
+}


### PR DESCRIPTION
# 요약
게시물(Post) 도메인의 핵심 CRUD API 개발을 완료했습니다.

API 구현 내용은 다음과 같습니다.

- `POST /posts`: 게시물 생성

- `GET /posts/{postId}`: 특정 게시물 상세 조회

- `GET /posts`: 전체 게시물 목록 조회

- `PATCH /posts/{postId}`: 게시물 수정

- `DELETE /posts/{postId}`: 게시물 삭제

성능 최적화를 위해 전체 목록 조회 API에 **페이징**(`Pageable`)을 적용했으며, **JOIN FETCH**를 사용하여 **N+1 문제**를 해결했습니다.
또한, 프론트엔드와의 원활한 협업을 위해 모든 API에 **Swagger 문서화**를 적용하고, 데이터 무결성을 보장하기 위해 요청 DTO에 **유효성 검사**(`@Valid`) 로직을 추가했습니다.
# 연관 이슈 및 Close 할 이슈 작성
#10

close #10

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?