### PR TITLE
[Feature] 대댓글 기능 개발 - feature/ddd-17

### DIFF
--- a/src/main/java/com/example/petner/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/example/petner/domain/comment/controller/CommentController.java
@@ -12,9 +12,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
-import java.net.URI;
 import java.util.List;
 
 @RestController
@@ -36,13 +34,7 @@ public class CommentController {
         Long currentMemberId = 1L;
         CommentResponse response = commentService.createComment(postId, currentMemberId, request);
 
-        URI location = ServletUriComponentsBuilder
-                .fromCurrentContextPath()
-                .path("/api/v1/comments/{id}")
-                .buildAndExpand(response.getCommentId())
-                .toUri();
-
-        return ResponseEntity.created(location).body(response);
+        return ResponseEntity.created(null).body(response);
     }
 
     @GetMapping("/posts/{postId}/comments")

--- a/src/main/java/com/example/petner/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/example/petner/domain/comment/controller/CommentController.java
@@ -1,0 +1,80 @@
+package com.example.petner.domain.comment.controller;
+
+import com.example.petner.domain.comment.dto.request.CommentCreateRequest;
+import com.example.petner.domain.comment.dto.request.CommentUpdateRequest;
+import com.example.petner.domain.comment.dto.response.CommentResponse;
+import com.example.petner.domain.comment.service.CommentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+@Tag(name = "댓글 (Comments)", description = "댓글 및 대댓글 관련 API")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping("/posts/{postId}/comments")
+    @Operation(summary = "댓글/대댓글 생성", description = "특정 게시물에 댓글 또는 대댓글을 생성합니다.")
+    @ApiResponse(responseCode = "201", description = "댓글 생성 성공")
+    public ResponseEntity<CommentResponse> createComment(
+            @Parameter(description = "게시물 ID") @PathVariable Long postId,
+            @Valid @RequestBody CommentCreateRequest request) {
+
+        // TODO: 추후 인증 기능이 구현되면, 현재 로그인한 사용자의 ID를 가져와서 사용해야 합니다.
+        Long currentMemberId = 1L;
+        CommentResponse response = commentService.createComment(postId, currentMemberId, request);
+
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentContextPath()
+                .path("/api/v1/comments/{id}")
+                .buildAndExpand(response.getCommentId())
+                .toUri();
+
+        return ResponseEntity.created(location).body(response);
+    }
+
+    @GetMapping("/posts/{postId}/comments")
+    @Operation(summary = "게시물 댓글 전체 조회", description = "특정 게시물의 모든 댓글을 계층 구조로 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "댓글 목록 조회 성공")
+    public ResponseEntity<List<CommentResponse>> getCommentsByPost(
+            @Parameter(description = "게시물 ID") @PathVariable Long postId) {
+
+        List<CommentResponse> response = commentService.getCommentsByPost(postId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/comments/{commentId}")
+    @Operation(summary = "댓글 수정", description = "특정 댓글을 수정합니다.")
+    @ApiResponse(responseCode = "200", description = "댓글 수정 성공")
+    public ResponseEntity<CommentResponse> updateComment(
+            @Parameter(description = "댓글 ID") @PathVariable Long commentId,
+            @Valid @RequestBody CommentUpdateRequest request) {
+
+        // TODO: 추후 인증 기능이 구현되면, 댓글 작성자와 현재 로그인한 사용자가 동일한지 확인해야 합니다.
+        CommentResponse response = commentService.updateComment(commentId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/comments/{commentId}")
+    @Operation(summary = "댓글 삭제", description = "특정 댓글을 삭제합니다.")
+    @ApiResponse(responseCode = "200", description = "댓글 삭제 성공")
+    public ResponseEntity<String> deleteComment(
+            @Parameter(description = "댓글 ID") @PathVariable Long commentId) {
+
+        // TODO: 추후 인증 기능이 구현되면, 댓글 작성자와 현재 로그인한 사용자가 동일한지 확인해야 합니다.
+        commentService.deleteComment(commentId);
+        return ResponseEntity.ok("댓글이 성공적으로 삭제되었습니다.");
+    }
+}

--- a/src/main/java/com/example/petner/domain/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/com/example/petner/domain/comment/dto/request/CommentCreateRequest.java
@@ -1,0 +1,22 @@
+package com.example.petner.domain.comment.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Schema(description = "댓글 생성 요청")
+public class CommentCreateRequest {
+
+    @Schema(description = "댓글 내용", example = "좋은 게시물이네요!")
+    @NotBlank(message = "댓글 내용은 비워둘 수 없습니다.")
+    private String content;
+
+    @Schema(description = "부모 댓글 ID (대댓글일 경우)", example = "1")
+    private Long parentCommentId;
+}

--- a/src/main/java/com/example/petner/domain/comment/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/com/example/petner/domain/comment/dto/request/CommentUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.example.petner.domain.comment.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Schema(description = "댓글 수정 요청")
+public class CommentUpdateRequest {
+
+    @Schema(description = "댓글 내용", example = "수정된 댓글 내용입니다.")
+    @NotBlank(message = "댓글 내용은 비워둘 수 없습니다.")
+    private String content;
+}

--- a/src/main/java/com/example/petner/domain/comment/dto/response/CommentResponse.java
+++ b/src/main/java/com/example/petner/domain/comment/dto/response/CommentResponse.java
@@ -1,0 +1,35 @@
+package com.example.petner.domain.comment.dto.response;
+
+import com.example.petner.domain.comment.entity.Comment;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+public class CommentResponse {
+
+    private final Long commentId;
+    private final String content;
+    private final String authorNickname;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+    private final Long parentCommentId;
+    private final boolean isReply;
+    private List<CommentResponse> replies;
+
+    public CommentResponse(Comment comment) {
+        this.commentId = comment.getCommentId();
+        this.content = comment.getContent();
+        this.authorNickname = comment.getMember().getNickname();
+        this.createdAt = comment.getCreatedAt();
+        this.updatedAt = comment.getUpdatedAt();
+        this.parentCommentId = comment.getParentComment() != null ? comment.getParentComment().getCommentId() : null;
+        this.isReply = comment.isReply();
+        this.replies = List.of();
+    }
+
+    public void setReplies(List<CommentResponse> replies) {
+        this.replies = replies;
+    }
+}

--- a/src/main/java/com/example/petner/domain/comment/entity/Comment.java
+++ b/src/main/java/com/example/petner/domain/comment/entity/Comment.java
@@ -11,6 +11,8 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "comments")
@@ -52,5 +54,13 @@ public class Comment {
         this.post = post;
         this.member = member;
         this.parentComment = parentComment;
+    }
+
+    public void update(String content) {
+        this.content = content;
+    }
+
+    public boolean isReply() {
+        return this.parentComment != null;
     }
 }

--- a/src/main/java/com/example/petner/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/petner/domain/comment/repository/CommentRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
@@ -17,12 +18,20 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findByMember(Member member);
 
-    @Query("SELECT c FROM Comment c WHERE c.post = :post AND c.parentComment IS NULL ORDER BY c.createdAt ASC")
+    @Query("SELECT c FROM Comment c JOIN FETCH c.member WHERE c.post = :post AND c.parentComment IS NULL ORDER BY c.createdAt ASC")
     List<Comment> findParentCommentsByPost(@Param("post") Post post);
 
-    @Query("SELECT c FROM Comment c WHERE c.parentComment = :parentComment ORDER BY c.createdAt ASC")
+    @Query("SELECT c FROM Comment c JOIN FETCH c.member WHERE c.parentComment = :parentComment ORDER BY c.createdAt ASC")
     List<Comment> findRepliesByParentComment(@Param("parentComment") Comment parentComment);
 
-    @Query("SELECT c FROM Comment c WHERE c.post = :post ORDER BY c.createdAt ASC")
+    @Query("SELECT c FROM Comment c JOIN FETCH c.member WHERE c.post = :post ORDER BY c.createdAt ASC")
     List<Comment> findByPostOrderByCreatedAtAsc(@Param("post") Post post);
+
+    @Query("SELECT c FROM Comment c JOIN FETCH c.member WHERE c.commentId = :commentId")
+    Optional<Comment> findByIdWithMember(@Param("commentId") Long commentId);
+
+    @Query("SELECT c FROM Comment c JOIN FETCH c.member JOIN FETCH c.post WHERE c.commentId = :commentId")
+    Optional<Comment> findByIdWithMemberAndPost(@Param("commentId") Long commentId);
+
+    Long countByPost(Post post);
 }

--- a/src/main/java/com/example/petner/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/petner/domain/comment/service/CommentService.java
@@ -63,7 +63,6 @@ public class CommentService {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
 
-        List<Comment> parentComments = commentRepository.findParentCommentsByPost(post);
         List<Comment> allComments = commentRepository.findByPostOrderByCreatedAtAsc(post);
 
         Map<Long, List<CommentResponse>> repliesMap = allComments.stream()
@@ -73,7 +72,8 @@ public class CommentService {
                         Collectors.mapping(CommentResponse::new, Collectors.toList())
                 ));
 
-        return parentComments.stream()
+        return allComments.stream()
+                .filter(comment -> !comment.isReply())
                 .map(comment -> {
                     CommentResponse response = new CommentResponse(comment);
                     response.setReplies(repliesMap.getOrDefault(comment.getCommentId(), List.of()));

--- a/src/main/java/com/example/petner/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/petner/domain/comment/service/CommentService.java
@@ -1,0 +1,102 @@
+package com.example.petner.domain.comment.service;
+
+import com.example.petner.domain.comment.dto.request.CommentCreateRequest;
+import com.example.petner.domain.comment.dto.request.CommentUpdateRequest;
+import com.example.petner.domain.comment.dto.response.CommentResponse;
+import com.example.petner.domain.comment.entity.Comment;
+import com.example.petner.domain.comment.repository.CommentRepository;
+import com.example.petner.domain.member.entity.Member;
+import com.example.petner.domain.member.repository.MemberRepository;
+import com.example.petner.domain.post.entity.Post;
+import com.example.petner.domain.post.repository.PostRepository;
+import com.example.petner.global.exception.ErrorCode;
+import com.example.petner.global.exception.customException.CommentException;
+import com.example.petner.global.exception.customException.MemberException;
+import com.example.petner.global.exception.customException.PostException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public CommentResponse createComment(Long postId, Long authorId, CommentCreateRequest request) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
+
+        Member author = memberRepository.findById(authorId)
+                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+
+        Comment parentComment = null;
+        if (request.getParentCommentId() != null) {
+            parentComment = commentRepository.findById(request.getParentCommentId())
+                    .orElseThrow(() -> new CommentException(ErrorCode.COMMENT_NOT_FOUND));
+
+            if (!parentComment.getPost().getPostId().equals(postId)) {
+                throw new CommentException(ErrorCode.COMMENT_POST_MISMATCH);
+            }
+        }
+
+        Comment comment = Comment.builder()
+                .content(request.getContent())
+                .post(post)
+                .member(author)
+                .parentComment(parentComment)
+                .build();
+
+        Comment savedComment = commentRepository.save(comment);
+        return new CommentResponse(savedComment);
+    }
+
+    public List<CommentResponse> getCommentsByPost(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
+
+        List<Comment> parentComments = commentRepository.findParentCommentsByPost(post);
+        List<Comment> allComments = commentRepository.findByPostOrderByCreatedAtAsc(post);
+
+        Map<Long, List<CommentResponse>> repliesMap = allComments.stream()
+                .filter(Comment::isReply)
+                .collect(Collectors.groupingBy(
+                        comment -> comment.getParentComment().getCommentId(),
+                        Collectors.mapping(CommentResponse::new, Collectors.toList())
+                ));
+
+        return parentComments.stream()
+                .map(comment -> {
+                    CommentResponse response = new CommentResponse(comment);
+                    response.setReplies(repliesMap.getOrDefault(comment.getCommentId(), List.of()));
+                    return response;
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public CommentResponse updateComment(Long commentId, CommentUpdateRequest request) {
+        Comment comment = commentRepository.findByIdWithMember(commentId)
+                .orElseThrow(() -> new CommentException(ErrorCode.COMMENT_NOT_FOUND));
+
+        comment.update(request.getContent());
+
+        return new CommentResponse(comment);
+    }
+
+    @Transactional
+    public void deleteComment(Long commentId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CommentException(ErrorCode.COMMENT_NOT_FOUND));
+
+        commentRepository.delete(comment);
+    }
+}

--- a/src/main/java/com/example/petner/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/petner/global/exception/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
     /* 댓글 관련 */
     COMMENT_NOT_FOUND("404-CM01", "댓글을 찾을 수 없습니다", HttpStatus.NOT_FOUND),
     COMMENT_ACCESS_DENIED("403-CM02", "댓글에 대한 접근 권한이 없습니다", HttpStatus.FORBIDDEN),
+    COMMENT_POST_MISMATCH("400-CM03", "댓글과 게시글이 일치하지 않습니다", HttpStatus.BAD_REQUEST),
 
     /* 보호소 관련 */
     SHELTER_NOT_FOUND("404-SH01", "보호소 정보를 찾을 수 없습니다", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/example/petner/global/exception/customException/CommentException.java
+++ b/src/main/java/com/example/petner/global/exception/customException/CommentException.java
@@ -1,0 +1,11 @@
+package com.example.petner.global.exception.customException;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import com.example.petner.global.exception.ErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public class CommentException extends RuntimeException {
+    private final ErrorCode errorCode;
+}


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->

게시물의 댓글 및 대댓글 기능을 구현했습니다.

- 대댓글 기능을 위해 `Comment` 엔티티에 자기 참조(self-reference) 관계를 설정했습니다.
- 댓글 CRUD 비즈니스 로직 및 아래의 API 엔드포인트를 구현했습니다.
  - `POST /posts/{postId}/comments`: 댓글/대댓글 생성
  - `GET /posts/{postId}/comments`: 특정 게시물 댓글 전체 조회
  - `PATCH /comments/{commentId}`: 댓글 수정
  - `DELETE /comments/{commentId}`: 댓글 삭제
- `@Valid`를 이용한 요청 데이터 유효성 검증을 적용했습니다.
- Swagger를 이용해 구현된 API를 문서화했습니다.
- 댓글 도메인 예외 처리 클래스 및 오류 코드 정의 추가했습니다.

# 연관 이슈 및 Close 할 이슈 작성
<!--이슈 번호를 적어주세요(예시: fix #123). -->
#17

close #17

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?