### PR TITLE
[Feature] 카카오 로그인 엔드 포인트 구현 - feature/ddd-11

### DIFF
--- a/src/main/java/com/example/petner/domain/auth/AUTH_GUIDE.md
+++ b/src/main/java/com/example/petner/domain/auth/AUTH_GUIDE.md
@@ -1,0 +1,253 @@
+# 🔐 PETNER 인증 시스템 (Kakao OAuth Session-based)
+
+## 📋 개요
+카카오 OAuth 2.0을 이용한 세션 기반 인증 시스템입니다. JWT 토큰 방식이 아닌 Redis Session을 활용한 전통적인 세션 인증을 구현했습니다.
+
+## 🏗️ 아키텍처
+
+### 전체 플로우
+```
+1. 카카오 로그인 요청 (/api/v1/auth/kakao/login)
+2. 카카오 OAuth 인증 페이지로 리다이렉트
+3. 사용자 로그인 후 콜백 (/api/v1/auth/kakao/callback)
+4. 카카오 API에서 사용자 정보 조회
+5. 임시 회원 생성 (kakaoId만 저장)
+6. 세션에 memberId 저장
+7. 프로필 완성 여부에 따라 추가 정보 입력 안내
+```
+
+### 핵심 설계 원칙
+- **SOLID 원칙 준수**: OAuthApiClient 인터페이스를 통한 DIP 적용
+- **트랜잭션 경계 최적화**: 외부 API 호출과 DB 작업 분리
+- **보안 강화**: 민감 정보 마스킹 및 최소 정보 노출
+- **근본적 해결**: 임시방편이 아닌 구조적 개선
+
+## 📁 구조
+
+```
+domain/auth/
+├── controller/
+│   └── AuthController.java       # REST API 엔드포인트
+├── service/
+│   └── AuthService.java          # 비즈니스 로직
+├── client/
+│   ├── OAuthApiClient.java       # OAuth 클라이언트 인터페이스
+│   └── KakaoApiClient.java       # 카카오 API 구현체
+├── dto/
+│   ├── KakaoUserInfo.java        # 카카오 사용자 정보 DTO
+│   └── response/
+│       ├── LoginResponse.java    # 로그인 응답 DTO
+│       ├── LogoutResponse.java   # 로그아웃 응답 DTO
+│       ├── MemberResponse.java   # 회원 정보 응답 DTO
+│       └── SessionResponse.java  # 세션 상태 응답 DTO
+└── README.md                     # 이 문서
+
+global/config/
+└── RestTemplateConfig.java       # HTTP 클라이언트 설정
+```
+
+## 🔧 구현된 기능
+
+### 0. RestTemplateConfig (Global 공통 설정)
+**역할:**
+- HTTP 클라이언트 및 JSON 처리 Bean 제공
+- 여러 도메인에서 공통으로 사용할 수 있는 인프라 설정
+
+**제공하는 Bean:**
+```java
+@Bean
+public RestTemplate restTemplate() {
+    return new RestTemplate();  // 외부 API 호출용 HTTP 클라이언트
+}
+
+@Bean  
+public ObjectMapper objectMapper() {
+    return new ObjectMapper();  // JSON ↔ Java 객체 변환 처리
+}
+```
+
+**사용 위치:**
+- `KakaoApiClient` 생성자에서 의존성 주입
+- 카카오 OAuth 토큰 요청/응답 처리
+- 카카오 사용자 정보 API 응답 파싱
+- 향후 다른 외부 API 호출 시에도 재사용 가능
+
+**Global 위치 이유:**
+- 진정한 공통 인프라 설정으로 여러 도메인에서 활용
+- RestTemplate과 ObjectMapper는 범용적 도구
+
+### 1. AuthController
+**엔드포인트:**
+- `GET /api/v1/auth/kakao/login` - 카카오 로그인 페이지로 리다이렉트
+- `GET /api/v1/auth/kakao/callback` - 카카오 콜백 처리 및 로그인
+- `POST /api/v1/auth/kakao/logout` - 로그아웃 (세션 무효화)
+- `GET /api/v1/auth/kakao/member` - 현재 로그인된 회원 정보 조회
+- `GET /api/v1/auth/kakao/session` - 세션 상태 확인
+
+**주요 특징:**
+- 생성자 주입을 통한 의존성 관리
+- 인증 코드 검증 및 에러 처리
+- 민감 정보 마스킹 (authorizationCode 로깅 시)
+
+### 2. AuthService
+**핵심 메서드:**
+- `kakaoLogin()` - 카카오 로그인 처리 (외부 API 호출)
+- `findOrCreateMemberWithTransaction()` - DB 작업만 트랜잭션 처리
+- `logout()` - 안전한 세션 무효화
+- `getCurrentMember()` - 세션 기반 회원 정보 조회
+- `getSessionStatus()` - 인증 상태 확인
+
+**최적화된 트랜잭션 설계:**
+```java
+// 외부 API 호출은 트랜잭션 밖에서
+public LoginResponse kakaoLogin(String authorizationCode, HttpSession session) {
+    String accessToken = oAuthApiClient.getAccessToken(authorizationCode);
+    KakaoUserInfo kakaoUserInfo = oAuthApiClient.getUserInfo(accessToken);
+    
+    // DB 작업만 트랜잭션으로 처리
+    Member member = findOrCreateMemberWithTransaction(kakaoUserInfo);
+    // ...
+}
+
+@Transactional
+protected Member findOrCreateMemberWithTransaction(KakaoUserInfo kakaoUserInfo) {
+    return findOrCreateMember(kakaoUserInfo);
+}
+```
+
+### 3. KakaoApiClient
+**SOLID 원칙 적용:**
+- `OAuthApiClient` 인터페이스 구현으로 DIP 준수
+- 생성자 주입을 통한 의존성 관리
+- 포괄적 예외 처리 및 로깅
+
+**안전한 API 호출:**
+```java
+// JSON 파싱 안전성 확보
+private KakaoUserInfo parseKakaoUserInfo(JsonNode jsonNode) {
+    if (jsonNode == null || jsonNode.get("id") == null) {
+        throw new MemberException(ErrorCode.KAKAO_API_ERROR);
+    }
+    // ...
+}
+```
+
+### 4. Member Entity 최적화
+**임시 회원 생성 패턴:**
+```java
+public static Member createTemporaryMember(String kakaoId) {
+    return Member.builder()
+            .kakaoId(kakaoId)  // 카카오 ID만 저장
+            .profileCompleted(false)
+            .build();
+}
+```
+
+**프로필 완성 검증:**
+```java
+public boolean isProfileComplete() {
+    return profileCompleted != null && profileCompleted 
+            && nickname != null     // 사용자 입력
+            && email != null        // 사용자 입력  
+            && gender != null 
+            && housingType != null 
+            && contact != null 
+            && location != null;
+}
+```
+
+### 5. 보안 강화
+**민감 정보 보호:**
+- 카카오 ID 마스킹: `1234****`
+- 인증 코드 마스킹: `abcd****`
+- 로그인 응답에서 최소 정보만 제공
+
+**MemberResponse 설계:**
+```java
+// 로그인 시 최소 정보만 제공
+public static MemberResponse forLogin(Member member) {
+    return MemberResponse.builder()
+            .memberId(member.getMemberId())
+            .profileCompleted(member.isProfileComplete())
+            .build();
+}
+```
+
+## 🚧 추가 작업 필요 사항
+
+### 1. 프로필 완성 API 구현
+```java
+// 구현 필요
+PUT /api/v1/members/profile
+{
+    "nickname": "사용자닉네임",
+    "email": "user@example.com",
+    "gender": "MALE",
+    "housingType": "APARTMENT", 
+    "contact": "010-1234-5678",
+    "locationId": 1
+}
+```
+
+### 2. 닉네임 중복 검사 API
+```java
+// 구현 필요
+GET /api/v1/members/nickname/check?nickname=원하는닉네임
+```
+
+### 3. 이메일 중복 검사 API
+```java
+// 구현 필요  
+GET /api/v1/members/email/check?email=user@example.com
+```
+
+### 4. 세션 관리 강화
+- 세션 타임아웃 설정
+- 동시 로그인 제한 (옵션)
+- 세션 하이재킹 방지
+
+### 5. 예외 처리 개선
+- 카카오 API 오류별 세분화된 처리
+- 사용자 친화적 에러 메시지
+- 재시도 로직 (네트워크 오류 시)
+
+### 6. 테스트 코드 작성
+- 단위 테스트 (Service, Controller)
+- 통합 테스트 (API 엔드포인트)
+- Mock을 활용한 외부 API 테스트
+
+### 7. API 문서화
+- Swagger/OpenAPI 설정
+- 요청/응답 예시 문서화
+- 에러 코드 정의서
+
+## 🔒 보안 고려사항
+
+### 현재 적용된 보안
+- ✅ 민감 정보 마스킹
+- ✅ 세션 기반 인증
+- ✅ 최소 권한 원칙 (최소 정보만 노출)
+
+### 추가 검토 필요
+- CSRF 보호 설정
+- 세션 고정 공격 방지
+- Rate Limiting (API 호출 제한)
+- 로그인 시도 제한
+
+## 📝 설정 파일
+**.env 파일 필수 환경변수:**
+```env
+KAKAO_CLIENT_ID=your_kakao_client_id
+KAKAO_CLIENT_SECRET=your_kakao_client_secret  
+KAKAO_REDIRECT_URI=http://localhost:8080/api/v1/auth/kakao/callback
+```
+
+## 🎯 다음 우선순위
+1. **프로필 완성 API 구현** (가장 우선)
+2. **닉네임/이메일 중복 검사** 
+3. **테스트 코드 작성**
+4. **API 문서화**
+
+---
+*마지막 업데이트: 2025-09-20*
+*작성자: Claude Code Assistant*

--- a/src/main/java/com/example/petner/domain/auth/client/KakaoApiClient.java
+++ b/src/main/java/com/example/petner/domain/auth/client/KakaoApiClient.java
@@ -1,0 +1,131 @@
+package com.example.petner.domain.auth.client;
+
+import com.example.petner.domain.auth.dto.KakaoUserInfo;
+import com.example.petner.global.exception.ErrorCode;
+import com.example.petner.global.exception.customException.MemberException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Component
+public class KakaoApiClient implements OAuthApiClient {
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    private final String clientId;
+    private final String clientSecret;
+    private final String redirectUri;
+
+    public KakaoApiClient(RestTemplate restTemplate,
+                         ObjectMapper objectMapper,
+                         @Value("${kakao.oauth.client-id}") String clientId,
+                         @Value("${kakao.oauth.client-secret}") String clientSecret,
+                         @Value("${kakao.oauth.redirect-uri}") String redirectUri) {
+        this.restTemplate = restTemplate;
+        this.objectMapper = objectMapper;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.redirectUri = redirectUri;
+    }
+
+    private static final String KAKAO_TOKEN_URL = "https://kauth.kakao.com/oauth/token";
+    private static final String KAKAO_USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
+
+    @Override
+    public String getAccessToken(String authorizationCode) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", clientId);
+        body.add("client_secret", clientSecret);
+        body.add("redirect_uri", redirectUri);
+        body.add("code", authorizationCode);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+
+        try {
+            ResponseEntity<String> response = restTemplate.postForEntity(KAKAO_TOKEN_URL, request, String.class);
+            
+            if (response.getStatusCode() == HttpStatus.OK) {
+                JsonNode jsonNode = objectMapper.readTree(response.getBody());
+                return jsonNode.get("access_token").asText();
+            } else {
+                log.warn("[카카오 API] 토큰 요청 실패: statusCode={}", response.getStatusCode());
+                throw new MemberException(ErrorCode.KAKAO_AUTH_FAILED);
+            }
+        } catch (Exception e) {
+            log.error("[카카오 API] 토큰 요청 중 시스템 오류 발생", e);
+            throw new MemberException(ErrorCode.KAKAO_API_ERROR);
+        }
+    }
+
+    @Override
+    public KakaoUserInfo getUserInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<String> request = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<String> response = restTemplate.exchange(
+                KAKAO_USER_INFO_URL, 
+                HttpMethod.GET, 
+                request, 
+                String.class
+            );
+
+            if (response.getStatusCode() == HttpStatus.OK) {
+                JsonNode jsonNode = objectMapper.readTree(response.getBody());
+                return parseKakaoUserInfo(jsonNode);
+            } else {
+                log.warn("[카카오 API] 사용자 정보 요청 실패: statusCode={}", response.getStatusCode());
+                throw new MemberException(ErrorCode.KAKAO_AUTH_FAILED);
+            }
+        } catch (Exception e) {
+            log.error("[카카오 API] 사용자 정보 요청 중 시스템 오류 발생", e);
+            throw new MemberException(ErrorCode.KAKAO_API_ERROR);
+        }
+    }
+
+    private KakaoUserInfo parseKakaoUserInfo(JsonNode jsonNode) {
+        try {
+            if (jsonNode == null || jsonNode.get("id") == null) {
+                throw new MemberException(ErrorCode.KAKAO_API_ERROR);
+            }
+            
+            String kakaoId = jsonNode.get("id").asText();
+            JsonNode kakaoAccount = jsonNode.get("kakao_account");
+            
+            if (kakaoAccount == null) {
+                throw new MemberException(ErrorCode.KAKAO_API_ERROR);
+            }
+            
+            JsonNode profile = kakaoAccount.get("profile");
+            String email = kakaoAccount.has("email") ? kakaoAccount.get("email").asText() : null;
+            String nickname = (profile != null && profile.has("nickname")) ? 
+                profile.get("nickname").asText() : null;
+
+            return KakaoUserInfo.builder()
+                    .kakaoId(kakaoId)
+                    .email(email)
+                    .nickname(nickname)
+                    .build();
+        } catch (MemberException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("[카카오 API] 응답 파싱 중 오류 발생", e);
+            throw new MemberException(ErrorCode.KAKAO_API_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/example/petner/domain/auth/client/OAuthApiClient.java
+++ b/src/main/java/com/example/petner/domain/auth/client/OAuthApiClient.java
@@ -1,0 +1,25 @@
+package com.example.petner.domain.auth.client;
+
+import com.example.petner.domain.auth.dto.KakaoUserInfo;
+
+/**
+ * OAuth API 클라이언트 인터페이스
+ * ISP(인터페이스 분리 원칙) 준수: OAuth 관련 기능만 정의
+ * DIP(의존성 역전 원칙) 준수: 고수준 모듈이 추상화에 의존
+ */
+public interface OAuthApiClient {
+    
+    /**
+     * Authorization Code를 사용하여 Access Token을 획득
+     * @param authorizationCode OAuth Authorization Code
+     * @return Access Token
+     */
+    String getAccessToken(String authorizationCode);
+    
+    /**
+     * Access Token을 사용하여 사용자 정보를 조회
+     * @param accessToken OAuth Access Token
+     * @return 사용자 정보
+     */
+    KakaoUserInfo getUserInfo(String accessToken);
+}

--- a/src/main/java/com/example/petner/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/petner/domain/auth/controller/AuthController.java
@@ -1,0 +1,82 @@
+package com.example.petner.domain.auth.controller;
+
+import com.example.petner.domain.auth.dto.response.LoginResponse;
+import com.example.petner.domain.auth.dto.response.LogoutResponse;
+import com.example.petner.domain.auth.dto.response.MemberResponse;
+import com.example.petner.domain.auth.dto.response.SessionResponse;
+import com.example.petner.domain.auth.service.AuthService;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.view.RedirectView;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/auth/kakao")
+public class AuthController {
+
+    private final AuthService authService;
+    private final String kakaoClientId;
+    private final String kakaoRedirectUri;
+
+    public AuthController(AuthService authService,
+                         @Value("${kakao.oauth.client-id}") String kakaoClientId,
+                         @Value("${kakao.oauth.redirect-uri}") String kakaoRedirectUri) {
+        this.authService = authService;
+        this.kakaoClientId = kakaoClientId;
+        this.kakaoRedirectUri = kakaoRedirectUri;
+    }
+
+    @GetMapping("/login")
+    public RedirectView kakaoLogin() {
+        String kakaoAuthUrl = "https://kauth.kakao.com/oauth/authorize" +
+                "?client_id=" + kakaoClientId +
+                "&redirect_uri=" + URLEncoder.encode(kakaoRedirectUri, StandardCharsets.UTF_8) +
+                "&response_type=code";
+        
+        log.info("[카카오 로그인] 요청 시작");
+        return new RedirectView(kakaoAuthUrl);
+    }
+
+    @GetMapping("/callback")
+    public ResponseEntity<LoginResponse> kakaoCallback(
+            @RequestParam("code") String authorizationCode,
+            HttpSession session) {
+        
+        if (authorizationCode == null || authorizationCode.trim().isEmpty()) {
+            log.warn("[카카오 콜백] 인증 코드가 비어있음");
+            throw new RuntimeException("인증 코드가 비어있습니다");
+        }
+        
+        String maskedCode = authorizationCode.length() > 4 ? 
+            authorizationCode.substring(0, 4) + "****" : "****";
+        log.info("[카카오 콜백] 처리 시작: code={}", maskedCode);
+        
+        LoginResponse response = authService.kakaoLogin(authorizationCode, session);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<LogoutResponse> logout(HttpSession session) {
+        LogoutResponse response = authService.logout(session);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/member")
+    public ResponseEntity<MemberResponse> getCurrentMember(HttpSession session) {
+        MemberResponse member = authService.getCurrentMember(session);
+        return ResponseEntity.ok(member);
+    }
+
+    @GetMapping("/session")
+    public ResponseEntity<SessionResponse> checkAuthentication(HttpSession session) {
+        SessionResponse sessionStatus = authService.getSessionStatus(session);
+        return ResponseEntity.ok(sessionStatus);
+    }
+}

--- a/src/main/java/com/example/petner/domain/auth/dto/KakaoUserInfo.java
+++ b/src/main/java/com/example/petner/domain/auth/dto/KakaoUserInfo.java
@@ -1,0 +1,12 @@
+package com.example.petner.domain.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class KakaoUserInfo {
+    private String kakaoId;
+    private String email;
+    private String nickname;
+}

--- a/src/main/java/com/example/petner/domain/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/example/petner/domain/auth/dto/response/LoginResponse.java
@@ -1,0 +1,11 @@
+package com.example.petner.domain.auth.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LoginResponse {
+    private String message;
+    private MemberResponse member;
+}

--- a/src/main/java/com/example/petner/domain/auth/dto/response/LogoutResponse.java
+++ b/src/main/java/com/example/petner/domain/auth/dto/response/LogoutResponse.java
@@ -1,0 +1,16 @@
+package com.example.petner.domain.auth.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LogoutResponse {
+    private String message;
+    
+    public static LogoutResponse success() {
+        return LogoutResponse.builder()
+                .message("로그아웃 성공")
+                .build();
+    }
+}

--- a/src/main/java/com/example/petner/domain/auth/dto/response/MemberResponse.java
+++ b/src/main/java/com/example/petner/domain/auth/dto/response/MemberResponse.java
@@ -1,0 +1,39 @@
+package com.example.petner.domain.auth.dto.response;
+
+import com.example.petner.domain.member.entity.Member;
+import com.example.petner.global.config.common.Gender;
+import com.example.petner.domain.member.common.HousingType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MemberResponse {
+    private Long memberId;
+    private String email;
+    private String nickname;
+    private Gender gender;
+    private HousingType housingType;
+    private boolean profileCompleted;
+
+    public static MemberResponse from(Member member) {
+        return MemberResponse.builder()
+                .memberId(member.getMemberId())
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .gender(member.getGender())
+                .housingType(member.getHousingType())
+                .profileCompleted(member.isProfileComplete())
+                .build();
+    }
+    
+    /**
+     * 로그인 직후 최소 정보만 제공하는 응답
+     */
+    public static MemberResponse forLogin(Member member) {
+        return MemberResponse.builder()
+                .memberId(member.getMemberId())
+                .profileCompleted(member.isProfileComplete())
+                .build();
+    }
+}

--- a/src/main/java/com/example/petner/domain/auth/dto/response/SessionResponse.java
+++ b/src/main/java/com/example/petner/domain/auth/dto/response/SessionResponse.java
@@ -1,0 +1,25 @@
+package com.example.petner.domain.auth.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SessionResponse {
+    private boolean authenticated;
+    private String status;
+    
+    public static SessionResponse authenticated() {
+        return SessionResponse.builder()
+                .authenticated(true)
+                .status("인증됨")
+                .build();
+    }
+    
+    public static SessionResponse unauthenticated() {
+        return SessionResponse.builder()
+                .authenticated(false)
+                .status("인증되지 않음")
+                .build();
+    }
+}

--- a/src/main/java/com/example/petner/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/petner/domain/auth/service/AuthService.java
@@ -1,0 +1,109 @@
+package com.example.petner.domain.auth.service;
+
+import com.example.petner.domain.auth.dto.KakaoUserInfo;
+import com.example.petner.domain.auth.dto.response.LoginResponse;
+import com.example.petner.domain.auth.dto.response.LogoutResponse;
+import com.example.petner.domain.auth.dto.response.MemberResponse;
+import com.example.petner.domain.auth.dto.response.SessionResponse;
+import com.example.petner.domain.member.entity.Member;
+import com.example.petner.domain.member.repository.MemberRepository;
+import com.example.petner.global.exception.ErrorCode;
+import com.example.petner.global.exception.customException.MemberException;
+import com.example.petner.domain.auth.client.OAuthApiClient;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private final OAuthApiClient oAuthApiClient;
+    private final MemberRepository memberRepository;
+    
+    private static final String SESSION_MEMBER_KEY = "member";
+
+    public LoginResponse kakaoLogin(String authorizationCode, HttpSession session) {
+        // 외부 API 호출을 트랜잭션 밖에서 실행
+        String accessToken = oAuthApiClient.getAccessToken(authorizationCode);
+        KakaoUserInfo kakaoUserInfo = oAuthApiClient.getUserInfo(accessToken);
+        
+        // 데이터베이스 작업만 트랜잭션으로 처리
+        Member member = findOrCreateMemberWithTransaction(kakaoUserInfo);
+        
+        session.setAttribute(SESSION_MEMBER_KEY, member.getMemberId());
+        
+        String maskedKakaoId = kakaoUserInfo.getKakaoId().length() > 4 ? 
+            kakaoUserInfo.getKakaoId().substring(0, 4) + "****" : "****";
+        log.info("[로그인] 성공: kakaoId={}, memberId={}", maskedKakaoId, member.getMemberId());
+        
+        return LoginResponse.builder()
+                .message("로그인 성공")
+                .member(MemberResponse.forLogin(member)) // 로그인용 최소 정보만 제공
+                .build();
+    }
+
+
+    @Transactional
+    protected Member findOrCreateMemberWithTransaction(KakaoUserInfo kakaoUserInfo) {
+        return findOrCreateMember(kakaoUserInfo);
+    }
+
+    private Member findOrCreateMember(KakaoUserInfo kakaoUserInfo) {
+        return memberRepository.findByKakaoId(kakaoUserInfo.getKakaoId())
+                .orElseGet(() -> createNewMember(kakaoUserInfo));
+    }
+    
+    private Member createNewMember(KakaoUserInfo kakaoUserInfo) {
+        try {
+            // 카카오 정보로 임시 회원 생성 (kakaoId만 저장)
+            Member newMember = Member.createTemporaryMember(
+                kakaoUserInfo.getKakaoId()
+            );
+            
+            Member savedMember = memberRepository.save(newMember);
+            log.info("[회원가입] 임시 회원 생성 완료: memberId={}, profileComplete={}", 
+                savedMember.getMemberId(), savedMember.isProfileComplete());
+            
+            return savedMember;
+        } catch (Exception e) {
+            log.error("[회원가입] 임시 회원 생성 실패: kakaoId={}", kakaoUserInfo.getKakaoId(), e);
+            throw new MemberException(ErrorCode.MEMBER_ALREADY_EXISTS);
+        }
+    }
+
+    public LogoutResponse logout(HttpSession session) {
+        try {
+            Long memberId = (Long) session.getAttribute(SESSION_MEMBER_KEY);
+            if (memberId != null) {
+                log.info("[로그아웃] 완료: memberId={}", memberId);
+            }
+            session.invalidate();
+            return LogoutResponse.success();
+        } catch (Exception e) {
+            log.warn("[로그아웃] 세션 무효화 실패", e);
+            return LogoutResponse.success(); // 클라이언트에게는 성공으로 응답
+        }
+    }
+
+    public MemberResponse getCurrentMember(HttpSession session) {
+        Long memberId = (Long) session.getAttribute(SESSION_MEMBER_KEY);
+        if (memberId == null) {
+            throw new MemberException(ErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+
+        return MemberResponse.from(member);
+    }
+
+    public SessionResponse getSessionStatus(HttpSession session) {
+        boolean isAuthenticated = session.getAttribute(SESSION_MEMBER_KEY) != null;
+        return isAuthenticated ? SessionResponse.authenticated() : SessionResponse.unauthenticated();
+    }
+}

--- a/src/main/java/com/example/petner/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/petner/global/config/RestTemplateConfig.java
@@ -1,0 +1,20 @@
+package com.example.petner.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/src/main/java/com/example/petner/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/petner/global/config/SecurityConfig.java
@@ -15,10 +15,16 @@ public class SecurityConfig {
         http
             .authorizeHttpRequests(authorize -> authorize
                 // Swagger UI 관련 경로 허용
-                .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html", "/ws-stomp/**"  ).permitAll()
-                .anyRequest().authenticated()
+                    .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html", "/ws-stomp/**"  ).permitAll()
+                // 개발 단계에서는 모든 요청 허용
+                .anyRequest().permitAll()
             )
-            .csrf(csrf -> csrf.disable());
+            .csrf(csrf -> csrf.disable())
+            .sessionManagement(session -> session
+                .sessionFixation().migrateSession()
+                .maximumSessions(1)
+                .maxSessionsPreventsLogin(false)
+            );
         
         return http.build();
     }

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -53,3 +53,8 @@ logging.level.org.springframework.security=${LOGGING_LEVEL_SECURITY}
 
 # Cookie settings for development (HTTP)
 cookie.secure=${COOKIE_SECURE}
+
+# Kakao OAuth Configuration
+kakao.oauth.client-id=${KAKAO_CLIENT_ID}
+kakao.oauth.client-secret=${KAKAO_CLIENT_SECRET}
+kakao.oauth.redirect-uri=${KAKAO_REDIRECT_URI}

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -33,3 +33,16 @@ logging.level.root=WARN
 logging.level.com.example.petner=INFO
 logging.level.org.springframework.test=INFO
 logging.level.org.springframework.data.redis=WARN
+
+# ---------- Kakao OAuth (Test) ----------
+kakao.oauth.client-id=test-client-id
+kakao.oauth.client-secret=test-client-secret
+kakao.oauth.redirect-uri=http://localhost:8080/api/v1/auth/kakao/callback
+
+# ---------- Cookie settings (Test) ----------
+cookie.secure=false
+
+# ---------- JWT (Test) ----------
+jwt.secret=test-secret-key-for-testing-purposes-only
+jwt.access-expiration=86400000
+jwt.refresh-expiration=604800000


### PR DESCRIPTION
# 요약

로그인 관련 auth 도메인 파트를 구현하였습니다.

중간에 카카오 로그인 쪽 구현 관련해서 이슈가 생겨 그 부분을 이슈 생성 및 처리 후 완료하였습니다.

구현과 관련된 자세한 내용은 auth 도메인 폴더 안에 AUTH_GUIDE.md 파일을 넣어두었습니다. 

이 파일은 다음 pr 시 삭제 예정입니다.

# 연관 이슈 및 Close 할 이슈 작성

#11 

close #11 

# Pull Request 체크리스트

## TODO

- [ ] 최종 결과물을 확인했는가?
- [ ] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat: 깃허브 로그인 버튼 컴포넌트 구현 (#10)
    - 나쁜 예시) feat: 로그인 구현