### PR TITLE
[Feature] 채팅방 논리적 삭제(Soft Delete) 기능 및 스키마 변경 - Feature/ddd 18

### DIFF
--- a/src/main/java/com/example/petner/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/example/petner/domain/chat/controller/ChatMessageController.java
@@ -41,7 +41,7 @@ public class ChatMessageController {
      * @param message 클라이언트가 전송한 메시지 데이터
      * @return 브로드캐스팅할 메시지 응답 DTO
      *
-     * @throws IllegalArgumentException 잘못된 채팅방 ID 또는 메시지 내용
+     * @throws ChatException 잘못된 채팅방 ID 또는 메시지 내용
      * @throws RuntimeException 메시지 저장 실패
      */
     @MessageMapping("/chat/{chatRoomId}")
@@ -62,7 +62,7 @@ public class ChatMessageController {
 
             return savedMessage;
 
-        } catch (IllegalArgumentException e) {
+        } catch (ChatException e) {
             log.warn("잘못된 메시지 요청 - 채팅방 ID: {}, 오류: {}", chatRoomId, e.getMessage());
             throw e;
         } catch (Exception e) {

--- a/src/main/java/com/example/petner/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/example/petner/domain/chat/controller/ChatRoomController.java
@@ -118,15 +118,62 @@ public class ChatRoomController {
         return ResponseEntity.ok(messages);
     }
 
+    /**
+     * 채팅방 나가기 API
+     * 실제 삭제가 아닌 비활성화 처리
+     *
+     * @param chatRoomId 나갈 채팅방 ID
+     * @param memberId 나갈 멤버 ID
+     * @return 처리 결과 (200 OK)
+     */
+    @DeleteMapping("/{chatRoomId}/members/{memberId}")
+    @Operation(summary = "채팅방 나가기", description = "채팅방에서 나갑니다 (비활성화 처리)")
+    @ApiResponse(responseCode = "200", description = "채팅방 나가기 성공")
+    public ResponseEntity<Void> leaveChatRoom(@PathVariable Long chatRoomId, @PathVariable Long memberId) {
+        chatRoomService.leaveChatRoom(chatRoomId, memberId);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 채팅방 재입장 API
+     * 비활성화된 멤버를 다시 활성화
+     *
+     * @param chatRoomId 재입장할 채팅방 ID
+     * @param memberId 재입장할 멤버 ID
+     * @return 처리 결과 (200 OK)
+     */
+    @PutMapping("/{chatRoomId}/members/{memberId}/rejoin")
+    @Operation(summary = "채팅방 재입장", description = "나간 채팅방에 다시 입장합니다")
+    @ApiResponse(responseCode = "200", description = "채팅방 재입장 성공")
+    public ResponseEntity<Void> rejoinChatRoom(@PathVariable Long chatRoomId, @PathVariable Long memberId) {
+        chatRoomService.rejoinChatRoom(chatRoomId, memberId);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 채팅방 활성 멤버 수 조회 API
+     * 채팅방 관리 및 통계 정보 제공
+     *
+     * @param chatRoomId 조회할 채팅방 ID
+     * @return 활성 멤버 수 (200 OK)
+     */
+    @GetMapping("/{chatRoomId}/members/count")
+    @Operation(summary = "채팅방 활성 멤버 수 조회", description = "채팅방의 활성 멤버 수를 조회합니다")
+    @ApiResponse(responseCode = "200", description = "활성 멤버 수 조회 성공")
+    public ResponseEntity<Long> getActiveMemberCount(@PathVariable Long chatRoomId) {
+        long count = chatRoomQueryService.getActiveMemberCount(chatRoomId);
+        return ResponseEntity.ok(count);
+    }
+
     @Operation(
             summary = "[WS] 채팅 메시지 전송 (문서화용)",
             description = """
             ###  WebSocket STOMP 프로토콜을 통해 메시지를 전송합니다.
-            
+
             - **구독(Subscribe) 주소**: `/topic/chat/{chatRoomId}`
             - **발행(Publish) 주소**: `/app/chat/{chatRoomId}`
             - **요청 본문 (Request Body)**: `ChatMessageRequestDto` 형식
-            
+
             이 HTTP 엔드포인트는 호출할 수 없으며, 오직 WebSocket 명세 확인용입니다.
             """
     )

--- a/src/main/java/com/example/petner/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/example/petner/domain/chat/controller/ChatRoomController.java
@@ -5,6 +5,8 @@ import com.example.petner.domain.chat.dto.request.ChatRoomCreateRequestDto;
 import com.example.petner.domain.chat.dto.response.ChatRoomResponseDto;
 import com.example.petner.domain.chat.dto.response.ChatRoomListResponseDto;
 import com.example.petner.domain.chat.dto.response.ChatMessageResponseDto;
+import com.example.petner.domain.chat.dto.response.ChatRoomMemberCountResponseDto;
+import com.example.petner.domain.chat.dto.response.ChatRoomActionResponseDto;
 import com.example.petner.domain.chat.service.ChatRoomService;
 import com.example.petner.domain.chat.service.ChatRoomQueryService;
 import com.example.petner.domain.chat.service.ChatMessageService;
@@ -129,9 +131,10 @@ public class ChatRoomController {
     @DeleteMapping("/{chatRoomId}/members/{memberId}")
     @Operation(summary = "채팅방 나가기", description = "채팅방에서 나갑니다 (비활성화 처리)")
     @ApiResponse(responseCode = "200", description = "채팅방 나가기 성공")
-    public ResponseEntity<Void> leaveChatRoom(@PathVariable Long chatRoomId, @PathVariable Long memberId) {
+    public ResponseEntity<ChatRoomActionResponseDto> leaveChatRoom(@PathVariable Long chatRoomId, @PathVariable Long memberId) {
         chatRoomService.leaveChatRoom(chatRoomId, memberId);
-        return ResponseEntity.ok().build();
+        ChatRoomActionResponseDto responseDto = new ChatRoomActionResponseDto(chatRoomId, memberId, "채팅방 나가기 성공");
+        return ResponseEntity.ok(responseDto);
     }
 
     /**
@@ -145,9 +148,10 @@ public class ChatRoomController {
     @PutMapping("/{chatRoomId}/members/{memberId}/rejoin")
     @Operation(summary = "채팅방 재입장", description = "나간 채팅방에 다시 입장합니다")
     @ApiResponse(responseCode = "200", description = "채팅방 재입장 성공")
-    public ResponseEntity<Void> rejoinChatRoom(@PathVariable Long chatRoomId, @PathVariable Long memberId) {
+    public ResponseEntity<ChatRoomActionResponseDto> rejoinChatRoom(@PathVariable Long chatRoomId, @PathVariable Long memberId) {
         chatRoomService.rejoinChatRoom(chatRoomId, memberId);
-        return ResponseEntity.ok().build();
+        ChatRoomActionResponseDto responseDto = new ChatRoomActionResponseDto(chatRoomId, memberId, "채팅방 재입장 성공");
+        return ResponseEntity.ok(responseDto);
     }
 
     /**
@@ -160,9 +164,10 @@ public class ChatRoomController {
     @GetMapping("/{chatRoomId}/members/count")
     @Operation(summary = "채팅방 활성 멤버 수 조회", description = "채팅방의 활성 멤버 수를 조회합니다")
     @ApiResponse(responseCode = "200", description = "활성 멤버 수 조회 성공")
-    public ResponseEntity<Long> getActiveMemberCount(@PathVariable Long chatRoomId) {
+    public ResponseEntity<ChatRoomMemberCountResponseDto> getActiveMemberCount(@PathVariable Long chatRoomId) {
         long count = chatRoomQueryService.getActiveMemberCount(chatRoomId);
-        return ResponseEntity.ok(count);
+        ChatRoomMemberCountResponseDto responseDto = new ChatRoomMemberCountResponseDto(chatRoomId, count);
+        return ResponseEntity.ok(responseDto);
     }
 
     @Operation(

--- a/src/main/java/com/example/petner/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/example/petner/domain/chat/controller/ChatRoomController.java
@@ -113,10 +113,54 @@ public class ChatRoomController {
      * @return 채팅방 전체 메시지 목록 (200 OK)
      */
     @GetMapping("/{chatRoomId}/messages/all")
-    @Operation(summary = "특정 채팅방의 메시지 내역 전체 조회(페이징 x)", description = "특정 채팅방의 메시지 내역을 전체 조회합니다")
+    @Operation(summary = "특정 채팅방의 메시지 내역 전체 조회(페이징 x)", description = "특정 채팅방의 메시지 내역을 전체 조회합니다(디버깅용)")
     @ApiResponse(responseCode = "201", description = "채팅방 메시지 내역 전체 조회 성공")
     public ResponseEntity<List<ChatMessageResponseDto>> getAllChatRoomMessages(@PathVariable Long chatRoomId) {
         List<ChatMessageResponseDto> messages = chatMessageService.getAllChatRoomMessages(chatRoomId);
+        return ResponseEntity.ok(messages);
+    }
+
+    /**
+     * 특정 채팅방의 멤버별 가시 메시지 조회 API (페이징)
+     *
+     * 멤버의 입장/나가기 이력에 따라 볼 수 있는 메시지만 반환
+     * 성능 최적화를 위한 페이징 지원
+     *
+     * @param chatRoomId 조회할 채팅방 ID
+     * @param memberId 조회 요청하는 멤버 ID
+     * @param page 페이지 번호 (선택, 기본값: 0)
+     * @param size 페이지 크기 (선택, 기본값: 50)
+     * @return 해당 멤버가 볼 수 있는 메시지 목록 (200 OK)
+     */
+    @GetMapping("/{chatRoomId}/messages/visible")
+    @Operation(summary = "멤버별 가시 메시지 조회 (페이징 o)", description = "멤버의 참여 이력에 따른 가시 메시지만 조회합니다 (페이징 지원)")
+    @ApiResponse(responseCode = "200", description = "가시 메시지 조회 성공")
+    public ResponseEntity<List<ChatMessageResponseDto>> getVisibleMessagesForMember(
+            @PathVariable Long chatRoomId,
+            @RequestParam Long memberId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "50") int size) {
+        List<ChatMessageResponseDto> messages = chatMessageService.getVisibleMessagesForMember(chatRoomId, memberId, page, size);
+        return ResponseEntity.ok(messages);
+    }
+
+    /**
+     * 특정 채팅방의 멤버별 가시 메시지 전체 조회 API (페이징 없음)
+     *
+     * 멤버의 입장/나가기 이력에 따라 볼 수 있는 메시지만 반환
+     * HTML 클라이언트에서 사용할 엔드포인트 (현재 사용중)
+     *
+     * @param chatRoomId 조회할 채팅방 ID
+     * @param memberId 조회 요청하는 멤버 ID
+     * @return 해당 멤버가 볼 수 있는 메시지 목록 (200 OK)
+     */
+    @GetMapping("/{chatRoomId}/messages/visible/all")
+    @Operation(summary = "멤버별 가시 메시지 전체 조회(페이징 x)", description = "멤버의 참여 이력에 따른 가시 메시지를 전체 조회합니다")
+    @ApiResponse(responseCode = "200", description = "가시 메시지 전체 조회 성공")
+    public ResponseEntity<List<ChatMessageResponseDto>> getAllVisibleMessagesForMember(
+            @PathVariable Long chatRoomId,
+            @RequestParam Long memberId) {
+        List<ChatMessageResponseDto> messages = chatMessageService.getVisibleMessagesForMember(chatRoomId, memberId);
         return ResponseEntity.ok(messages);
     }
 

--- a/src/main/java/com/example/petner/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/example/petner/domain/chat/controller/ChatRoomController.java
@@ -121,7 +121,7 @@ public class ChatRoomController {
     }
 
     /**
-     * 채팅방 나가기 API
+     *  채팅방 나가기 API
      * 실제 삭제가 아닌 비활성화 처리
      *
      * @param chatRoomId 나갈 채팅방 ID

--- a/src/main/java/com/example/petner/domain/chat/dto/response/ChatRoomActionResponseDto.java
+++ b/src/main/java/com/example/petner/domain/chat/dto/response/ChatRoomActionResponseDto.java
@@ -1,0 +1,50 @@
+package com.example.petner.domain.chat.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 채팅방 액션 성공 응답을 위한 DTO 클래스
+ *
+ * 서버에서 클라이언트로 채팅방 관련 액션(나가기, 재입장 등)의 성공 메시지를 전달할 때 사용하는 데이터 전송 객체입니다.
+ * 채팅방 나가기, 재입장 API의 응답으로 사용됩니다.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoomActionResponseDto {
+
+    /**
+     * 채팅방 고유 ID
+     */
+    private Long chatRoomId;
+
+    /**
+     * 멤버 고유 ID
+     */
+    private Long memberId;
+
+    /**
+     * 성공 메시지
+     */
+    private String message;
+
+    /**
+     * 액션 성공 상태
+     */
+    private boolean success;
+
+    /**
+     * 채팅방 액션 성공 응답 DTO 생성자
+     *
+     * @param chatRoomId 채팅방 고유 ID
+     * @param memberId 멤버 고유 ID
+     * @param message 성공 메시지
+     */
+    public ChatRoomActionResponseDto(Long chatRoomId, Long memberId, String message) {
+        this.chatRoomId = chatRoomId;
+        this.memberId = memberId;
+        this.message = message;
+        this.success = true;
+    }
+}

--- a/src/main/java/com/example/petner/domain/chat/dto/response/ChatRoomMemberCountResponseDto.java
+++ b/src/main/java/com/example/petner/domain/chat/dto/response/ChatRoomMemberCountResponseDto.java
@@ -1,0 +1,37 @@
+package com.example.petner.domain.chat.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 채팅방 활성 멤버 수 응답을 위한 DTO 클래스
+ *
+ * 서버에서 클라이언트로 채팅방의 활성 멤버 수 정보를 전달할 때 사용하는 데이터 전송 객체입니다.
+ * 채팅방 통계 정보 조회 API의 응답으로 사용됩니다.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoomMemberCountResponseDto {
+
+    /**
+     * 채팅방 고유 ID
+     */
+    private Long chatRoomId;
+
+    /**
+     * 활성 멤버 수
+     */
+    private Long activeMemberCount;
+
+    /**
+     * 활성 멤버 수 응답 DTO 생성자
+     *
+     * @param chatRoomId 채팅방 고유 ID
+     * @param activeMemberCount 활성 멤버 수
+     */
+    public ChatRoomMemberCountResponseDto(Long chatRoomId, Long activeMemberCount) {
+        this.chatRoomId = chatRoomId;
+        this.activeMemberCount = activeMemberCount;
+    }
+}

--- a/src/main/java/com/example/petner/domain/chat/dto/response/ChatRoomResponseDto.java
+++ b/src/main/java/com/example/petner/domain/chat/dto/response/ChatRoomResponseDto.java
@@ -1,17 +1,24 @@
 package com.example.petner.domain.chat.dto.response;
 
 import com.example.petner.domain.chat.entity.ChatRoom;
+import com.example.petner.domain.chat.entity.ChatRoomMember;
+import com.example.petner.domain.member.entity.Member;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * 채팅방 정보 응답을 위한 DTO 클래스
  *
  * 서버에서 클라이언트로 채팅방 정보를 전달할 때 사용하는 데이터 전송 객체입니다.
  * 채팅방 생성 API의 응답이나 특정 채팅방 조회 시 사용됩니다.
+ *
+ * 변경사항:
+ * - member1, member2 대신 ChatRoomMember를 통한 멤버 정보 관리
+ * - 활성 멤버만 포함하여 응답
  */
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -40,24 +47,10 @@ public class ChatRoomResponseDto {
     private String dogName;
 
     /**
-     * 첫 번째 멤버 ID
+     * 활성 멤버 정보 목록
+     * 채팅방에 참여 중인 멤버들의 기본 정보
      */
-    private Long member1Id;
-
-    /**
-     * 첫 번째 멤버 닉네임
-     */
-    private String member1Nickname;
-
-    /**
-     * 두 번째 멤버 ID
-     */
-    private Long member2Id;
-
-    /**
-     * 두 번째 멤버 닉네임
-     */
-    private String member2Nickname;
+    private List<MemberInfo> activeMembers;
 
     /**
      * ChatRoom 엔티티로부터 DTO를 생성하는 생성자
@@ -72,10 +65,23 @@ public class ChatRoomResponseDto {
         this.dogId = chatRoom.getDog() != null ? chatRoom.getDog().getDogId() : null;
         this.dogName = chatRoom.getDog() != null ? chatRoom.getDog().getName() : null;
 
-        // 멤버 정보 설정
-        this.member1Id = chatRoom.getMember1().getMemberId();
-        this.member1Nickname = chatRoom.getMember1().getNickname();
-        this.member2Id = chatRoom.getMember2().getMemberId();
-        this.member2Nickname = chatRoom.getMember2().getNickname();
+        // 활성 멤버 정보 설정
+        this.activeMembers = chatRoom.getActiveMembers().stream()
+                .map(chatRoomMember -> new MemberInfo(chatRoomMember.getMember()))
+                .toList();
+    }
+
+    /**
+     * 멤버 기본 정보를 담는 내부 클래스
+     */
+    @Getter
+    public static class MemberInfo {
+        private final Long memberId;
+        private final String nickname;
+
+        public MemberInfo(Member member) {
+            this.memberId = member.getMemberId();
+            this.nickname = member.getNickname();
+        }
     }
 }

--- a/src/main/java/com/example/petner/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/example/petner/domain/chat/entity/ChatRoom.java
@@ -1,7 +1,6 @@
 package com.example.petner.domain.chat.entity;
 
 import com.example.petner.domain.dog.entity.Dog;
-import com.example.petner.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -11,7 +10,17 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
+/**
+ * 채팅방 엔티티
+ *
+ * 변경사항:
+ * - member_id1, member_id2 컬럼 제거
+ * - ChatRoomMember 엔티티와 OneToMany 관계 설정
+ * - 채팅방 참여자 관리는 ChatRoomMember를 통해 처리
+ */
 @Entity
 @Table(name = "chat_rooms")
 @Getter
@@ -35,21 +44,48 @@ public class ChatRoom {
     @JoinColumn(name = "dog_id")
     private Dog dog;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id1", nullable = false)
-    private Member member1;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id2", nullable = false)
-    private Member member2;
+    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<ChatRoomMember> chatRoomMembers = new ArrayList<>();
 
     @Builder
-    public ChatRoom(Dog dog, Member member1, Member member2) {
+    public ChatRoom(Dog dog) {
         this.dog = dog;
-        this.member1 = member1;
-        this.member2 = member2;
+        this.chatRoomMembers = new ArrayList<>();
     }
 
+    /**
+     * 채팅방에 멤버 추가
+     * @param chatRoomMember 추가할 채팅방 멤버
+     */
+    public void addMember(ChatRoomMember chatRoomMember) {
+        chatRoomMembers.add(chatRoomMember);
+        chatRoomMember.setChatRoom(this);
+    }
+
+    /**
+     * 채팅방에서 멤버 제거 (실제 삭제가 아닌 비활성화)
+     * @param memberId 제거할 멤버 ID
+     */
+    public void removeMember(Long memberId) {
+        chatRoomMembers.stream()
+                .filter(member -> member.getMember().getMemberId().equals(memberId))
+                .findFirst()
+                .ifPresent(ChatRoomMember::deactivate);
+    }
+
+    /**
+     * 활성화된 채팅방 멤버 목록 조회
+     * @return 활성화된 멤버 목록
+     */
+    public List<ChatRoomMember> getActiveMembers() {
+        return chatRoomMembers.stream()
+                .filter(ChatRoomMember::isActive)
+                .toList();
+    }
+
+    /**
+     * 마지막 메시지 시간 업데이트
+     */
     public void updateLastMessageTime() {
         this.updatedAt = LocalDateTime.now();
     }

--- a/src/main/java/com/example/petner/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/example/petner/domain/chat/entity/ChatRoom.java
@@ -84,6 +84,14 @@ public class ChatRoom {
     }
 
     /**
+     * 전체 채팅방 멤버 목록 조회 (활성/비활성 모두 포함)
+     * @return 전체 멤버 목록
+     */
+    public List<ChatRoomMember> getAllMembers() {
+        return new ArrayList<>(chatRoomMembers);
+    }
+
+    /**
      * 마지막 메시지 시간 업데이트
      */
     public void updateLastMessageTime() {

--- a/src/main/java/com/example/petner/domain/chat/entity/ChatRoomMember.java
+++ b/src/main/java/com/example/petner/domain/chat/entity/ChatRoomMember.java
@@ -105,6 +105,14 @@ public class ChatRoomMember {
     }
 
     /**
+     * 입장 시간 조회
+     * @return 입장 시간
+     */
+    public LocalDateTime getJoinedAt() {
+        return this.joinedAt;
+    }
+
+    /**
      * 특정 시간 이후에 나간 상태인지 확인
      * @param messageTime 확인할 메시지 시간
      * @return 메시지 시간 이후에 나간 상태인지 여부

--- a/src/main/java/com/example/petner/domain/chat/entity/ChatRoomMember.java
+++ b/src/main/java/com/example/petner/domain/chat/entity/ChatRoomMember.java
@@ -19,7 +19,12 @@ import java.time.LocalDateTime;
  * 복합 유니크 키: (chat_room_id, member_id)
  */
 @Entity
-@Table(name = "chat_room_members")
+@Table(name = "chat_room_members", uniqueConstraints = {
+        @UniqueConstraint(
+                name = "chatroom_member_uk",
+                columnNames = {"chat_room_id", "member_id"}
+        )
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChatRoomMember {
@@ -73,8 +78,19 @@ public class ChatRoomMember {
      * @param chatRoom 설정할 채팅방
      */
     public void setChatRoom(ChatRoom chatRoom) {
+        // 기존 관계 해제
+        if (this.chatRoom != null && this.chatRoom != chatRoom) {
+            this.chatRoom.getChatRoomMembers().remove(this);
+        }
+
         this.chatRoom = chatRoom;
+
+        // 새로운 관계 설정 (무한 순환 방지)
+        if (chatRoom != null && !chatRoom.getChatRoomMembers().contains(this)) {
+            chatRoom.getChatRoomMembers().add(this);
+        }
     }
+
 
     /**
      * 채팅방 비활성화 (나가기)

--- a/src/main/java/com/example/petner/domain/chat/entity/ChatRoomMember.java
+++ b/src/main/java/com/example/petner/domain/chat/entity/ChatRoomMember.java
@@ -52,11 +52,20 @@ public class ChatRoomMember {
     @Column(name = "exited_at")
     private LocalDateTime exitedAt;
 
+    /**
+     * 채팅방에 (재)입장한 시간
+     * 채팅방 생성 시점 또는 재입장 시점으로 설정
+     * 이 시간 이전의 메시지는 보이지 않음
+     */
+    @Column(name = "joined_at")
+    private LocalDateTime joinedAt;
+
     @Builder
     public ChatRoomMember(ChatRoom chatRoom, Member member, Boolean isActive) {
         this.chatRoom = chatRoom;
         this.member = member;
         this.isActive = isActive != null ? isActive : true;
+        this.joinedAt = LocalDateTime.now(); // 생성 시점을 입장 시간으로 설정
     }
 
     /**
@@ -79,10 +88,12 @@ public class ChatRoomMember {
     /**
      * 채팅방 재활성화 (재입장)
      * 기존 멤버가 채팅방에 다시 참여할 때 사용
+     * 재입장 시점을 기록하여 이전 메시지 가시성 제어
      */
     public void reactivate() {
         this.isActive = true;
         this.exitedAt = null;
+        this.joinedAt = LocalDateTime.now(); // 재입장 시간 업데이트
     }
 
     /**
@@ -100,5 +111,26 @@ public class ChatRoomMember {
      */
     public boolean hasExitedAfter(LocalDateTime messageTime) {
         return exitedAt != null && exitedAt.isAfter(messageTime);
+    }
+
+    /**
+     * 멤버에게 특정 메시지가 보여야 하는지 확인
+     * 입장 시간 이후이고 나가기 전(또는 나간 적 없음)의 메시지만 보임
+     *
+     * @param messageTime 확인할 메시지 시간
+     * @return 메시지 가시성 여부
+     */
+    public boolean canSeeMessage(LocalDateTime messageTime) {
+        // 입장 시간 이전의 메시지는 보이지 않음
+        if (joinedAt != null && messageTime.isBefore(joinedAt)) {
+            return false;
+        }
+
+        // 나간 시간 이후의 메시지는 보이지 않음
+        if (exitedAt != null && messageTime.isAfter(exitedAt)) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/main/java/com/example/petner/domain/chat/entity/ChatRoomMember.java
+++ b/src/main/java/com/example/petner/domain/chat/entity/ChatRoomMember.java
@@ -31,7 +31,7 @@ public class ChatRoomMember {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id")
+    @Column(name = "chat_room_member_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/example/petner/domain/chat/entity/ChatRoomMember.java
+++ b/src/main/java/com/example/petner/domain/chat/entity/ChatRoomMember.java
@@ -1,0 +1,104 @@
+package com.example.petner.domain.chat.entity;
+
+import com.example.petner.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 채팅방 멤버 엔티티
+ *
+ * 채팅방과 멤버 간의 다대다 관계를 관리하는 중간 엔티티
+ * 멤버별 채팅방 참여 상태 및 나간 시간을 추적
+ *
+ * DB 테이블: chat_room_members
+ * 복합 유니크 키: (chat_room_id, member_id)
+ */
+@Entity
+@Table(name = "chat_room_members")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoomMember {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id", nullable = false)
+    private ChatRoom chatRoom;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    /**
+     * 채팅방 목록 노출 여부
+     * true: 채팅방 목록에 표시
+     * false: 채팅방을 나간 상태로 목록에서 숨김
+     */
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive = true;
+
+    /**
+     * 채팅방을 나간 시간
+     * 채팅방을 나갔을 때 설정되며, 이 시간 이후의 메시지는 보이지 않음
+     */
+    @Column(name = "exited_at")
+    private LocalDateTime exitedAt;
+
+    @Builder
+    public ChatRoomMember(ChatRoom chatRoom, Member member, Boolean isActive) {
+        this.chatRoom = chatRoom;
+        this.member = member;
+        this.isActive = isActive != null ? isActive : true;
+    }
+
+    /**
+     * 채팅방 설정 (양방향 관계 설정용)
+     * @param chatRoom 설정할 채팅방
+     */
+    public void setChatRoom(ChatRoom chatRoom) {
+        this.chatRoom = chatRoom;
+    }
+
+    /**
+     * 채팅방 비활성화 (나가기)
+     * 실제 데이터 삭제 대신 비활성화 처리하여 데이터 무결성 유지
+     */
+    public void deactivate() {
+        this.isActive = false;
+        this.exitedAt = LocalDateTime.now();
+    }
+
+    /**
+     * 채팅방 재활성화 (재입장)
+     * 기존 멤버가 채팅방에 다시 참여할 때 사용
+     */
+    public void reactivate() {
+        this.isActive = true;
+        this.exitedAt = null;
+    }
+
+    /**
+     * 활성 상태 확인
+     * @return 활성 상태 여부
+     */
+    public boolean isActive() {
+        return this.isActive;
+    }
+
+    /**
+     * 특정 시간 이후에 나간 상태인지 확인
+     * @param messageTime 확인할 메시지 시간
+     * @return 메시지 시간 이후에 나간 상태인지 여부
+     */
+    public boolean hasExitedAfter(LocalDateTime messageTime) {
+        return exitedAt != null && exitedAt.isAfter(messageTime);
+    }
+}

--- a/src/main/java/com/example/petner/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/example/petner/domain/chat/repository/ChatRoomMemberRepository.java
@@ -1,0 +1,90 @@
+package com.example.petner.domain.chat.repository;
+
+import com.example.petner.domain.chat.entity.ChatRoom;
+import com.example.petner.domain.chat.entity.ChatRoomMember;
+import com.example.petner.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 채팅방 멤버 Repository
+ *
+ * 채팅방 참여자 관리를 위한 데이터 액세스 계층
+ * N+1 문제 방지를 위한 최적화된 쿼리 제공
+ */
+@Repository
+public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, Long> {
+
+    /**
+     * 채팅방과 멤버로 채팅방 멤버 정보 조회
+     * @param chatRoom 채팅방
+     * @param member 멤버
+     * @return 채팅방 멤버 정보
+     */
+    Optional<ChatRoomMember> findByChatRoomAndMember(ChatRoom chatRoom, Member member);
+
+    /**
+     * 채팅방의 활성 멤버 목록 조회
+     * @param chatRoom 채팅방
+     * @return 활성 멤버 목록
+     */
+    @Query("SELECT crm FROM ChatRoomMember crm " +
+           "JOIN FETCH crm.member " +
+           "WHERE crm.chatRoom = :chatRoom AND crm.isActive = true")
+    List<ChatRoomMember> findActiveMembersByChatRoom(@Param("chatRoom") ChatRoom chatRoom);
+
+    /**
+     * 멤버가 참여한 활성 채팅방 목록 조회 (N+1 문제 방지)
+     * @param memberId 멤버 ID
+     * @return 활성 채팅방 목록
+     */
+    @Query("SELECT crm FROM ChatRoomMember crm " +
+           "JOIN FETCH crm.chatRoom cr " +
+           "LEFT JOIN FETCH cr.dog " +
+           "WHERE crm.member.memberId = :memberId AND crm.isActive = true " +
+           "ORDER BY cr.updatedAt DESC")
+    List<ChatRoomMember> findActiveChatRoomsByMemberId(@Param("memberId") Long memberId);
+
+    /**
+     * 채팅방에서 특정 멤버가 활성 상태인지 확인
+     * @param chatRoomId 채팅방 ID
+     * @param memberId 멤버 ID
+     * @return 활성 상태 여부
+     */
+    @Query("SELECT CASE WHEN COUNT(crm) > 0 THEN true ELSE false END " +
+           "FROM ChatRoomMember crm " +
+           "WHERE crm.chatRoom.chatRoomId = :chatRoomId " +
+           "AND crm.member.memberId = :memberId " +
+           "AND crm.isActive = true")
+    boolean existsActiveMemberInChatRoom(@Param("chatRoomId") Long chatRoomId, @Param("memberId") Long memberId);
+
+    /**
+     * 두 멤버가 함께 참여한 채팅방의 활성 멤버 정보 조회
+     * @param member1Id 첫 번째 멤버 ID
+     * @param member2Id 두 번째 멤버 ID
+     * @return 공통 참여 채팅방의 멤버 정보 목록
+     */
+    @Query("SELECT crm1 FROM ChatRoomMember crm1 " +
+           "WHERE crm1.member.memberId = :member1Id AND crm1.isActive = true " +
+           "AND EXISTS (" +
+           "    SELECT crm2 FROM ChatRoomMember crm2 " +
+           "    WHERE crm2.member.memberId = :member2Id " +
+           "    AND crm2.chatRoom = crm1.chatRoom " +
+           "    AND crm2.isActive = true" +
+           ")")
+    List<ChatRoomMember> findCommonActiveChatRooms(@Param("member1Id") Long member1Id, @Param("member2Id") Long member2Id);
+
+    /**
+     * 특정 채팅방의 활성 멤버 수 조회
+     * @param chatRoomId 채팅방 ID
+     * @return 활성 멤버 수
+     */
+    @Query("SELECT COUNT(crm) FROM ChatRoomMember crm " +
+           "WHERE crm.chatRoom.chatRoomId = :chatRoomId AND crm.isActive = true")
+    long countActiveMembersByChatRoomId(@Param("chatRoomId") Long chatRoomId);
+}

--- a/src/main/java/com/example/petner/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/example/petner/domain/chat/repository/ChatRoomRepository.java
@@ -29,7 +29,7 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     List<ChatRoom> findByDog(Dog dog);
 
     /**
-     * 특정 강아지와 관련된 채팅방 중에서 두 멤버가 참여한 채팅방 조회
+     * 특정 강아지와 관련된 채팅방 중에서 두 멤버가 참여한 채팅방 조회 (활성 멤버만)
      * ChatRoomMember를 통해 멤버 관계를 확인
      * @param dogId 강아지 ID
      * @param member1Id 첫 번째 멤버 ID
@@ -48,7 +48,26 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
                                                     @Param("member2Id") Long member2Id);
 
     /**
-     * 강아지 정보가 없는 채팅방 중에서 두 멤버가 참여한 채팅방 조회
+     * 특정 강아지와 관련된 채팅방 중에서 두 멤버가 참여한 채팅방 조회 (활성/비활성 무관)
+     * ChatRoomMember를 통해 멤버 관계를 확인
+     * @param dogId 강아지 ID
+     * @param member1Id 첫 번째 멤버 ID
+     * @param member2Id 두 번째 멤버 ID
+     * @return 조건에 맞는 채팅방
+     */
+    @Query("SELECT DISTINCT cr FROM ChatRoom cr " +
+           "JOIN cr.chatRoomMembers crm1 " +
+           "JOIN cr.chatRoomMembers crm2 " +
+           "WHERE cr.dog.dogId = :dogId " +
+           "AND crm1.member.memberId = :member1Id " +
+           "AND crm2.member.memberId = :member2Id " +
+           "AND crm1.id != crm2.id")
+    Optional<ChatRoom> findByDogAndTwoMembers(@Param("dogId") Long dogId,
+                                              @Param("member1Id") Long member1Id,
+                                              @Param("member2Id") Long member2Id);
+
+    /**
+     * 강아지 정보가 없는 채팅방 중에서 두 멤버가 참여한 채팅방 조회 (활성 멤버만)
      * @param member1Id 첫 번째 멤버 ID
      * @param member2Id 두 번째 멤버 ID
      * @return 조건에 맞는 채팅방
@@ -62,6 +81,22 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
            "AND crm1.id != crm2.id")
     Optional<ChatRoom> findByTwoActiveMembersAndNullDog(@Param("member1Id") Long member1Id,
                                                         @Param("member2Id") Long member2Id);
+
+    /**
+     * 강아지 정보가 없는 채팅방 중에서 두 멤버가 참여한 채팅방 조회 (활성/비활성 무관)
+     * @param member1Id 첫 번째 멤버 ID
+     * @param member2Id 두 번째 멤버 ID
+     * @return 조건에 맞는 채팅방
+     */
+    @Query("SELECT DISTINCT cr FROM ChatRoom cr " +
+           "JOIN cr.chatRoomMembers crm1 " +
+           "JOIN cr.chatRoomMembers crm2 " +
+           "WHERE cr.dog IS NULL " +
+           "AND crm1.member.memberId = :member1Id " +
+           "AND crm2.member.memberId = :member2Id " +
+           "AND crm1.id != crm2.id")
+    Optional<ChatRoom> findByTwoMembersAndNullDog(@Param("member1Id") Long member1Id,
+                                                  @Param("member2Id") Long member2Id);
 
     /**
      * 두 멤버가 공통으로 참여한 모든 활성 채팅방 조회 (강아지 정보 포함)

--- a/src/main/java/com/example/petner/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/example/petner/domain/chat/repository/ChatRoomRepository.java
@@ -1,9 +1,7 @@
 package com.example.petner.domain.chat.repository;
 
-import com.example.petner.domain.chat.dto.response.ChatRoomListResponseDto;
 import com.example.petner.domain.chat.entity.ChatRoom;
 import com.example.petner.domain.dog.entity.Dog;
-import com.example.petner.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,31 +10,98 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * 채팅방 Repository
+ *
+ * 변경사항:
+ * - member_id1, member_id2 관련 쿼리 제거
+ * - ChatRoomMember를 통한 관계 관리로 변경
+ * - N+1 문제 방지를 위한 최적화된 쿼리 제공
+ */
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
-    @Query("SELECT cr FROM ChatRoom cr WHERE (cr.member1 = :member1 AND cr.member2 = :member2) OR (cr.member1 = :member2 AND cr.member2 = :member1)")
-    Optional<ChatRoom> findByTwoMembers(@Param("member1") Member member1, @Param("member2") Member member2);
-
-    @Query("SELECT cr FROM ChatRoom cr WHERE cr.member1 = :member OR cr.member2 = :member ORDER BY cr.updatedAt DESC")
-    List<ChatRoom> findByMemberOrderByUpdatedAtDesc(@Param("member") Member member);
-
+    /**
+     * 강아지와 관련된 채팅방 목록 조회
+     * @param dog 강아지 엔티티
+     * @return 해당 강아지와 관련된 채팅방 목록
+     */
     List<ChatRoom> findByDog(Dog dog);
 
-    @Query("SELECT cr FROM ChatRoom cr WHERE cr.dog = :dog AND ((cr.member1 = :member1 AND cr.member2 = :member2) OR (cr.member1 = :member2 AND cr.member2 = :member1))")
-    Optional<ChatRoom> findByDogAndTwoMembers(@Param("dog") Dog dog, @Param("member1") Member member1, @Param("member2") Member member2);
+    /**
+     * 특정 강아지와 관련된 채팅방 중에서 두 멤버가 참여한 채팅방 조회
+     * ChatRoomMember를 통해 멤버 관계를 확인
+     * @param dogId 강아지 ID
+     * @param member1Id 첫 번째 멤버 ID
+     * @param member2Id 두 번째 멤버 ID
+     * @return 조건에 맞는 채팅방
+     */
+    @Query("SELECT DISTINCT cr FROM ChatRoom cr " +
+           "JOIN cr.chatRoomMembers crm1 " +
+           "JOIN cr.chatRoomMembers crm2 " +
+           "WHERE cr.dog.dogId = :dogId " +
+           "AND crm1.member.memberId = :member1Id AND crm1.isActive = true " +
+           "AND crm2.member.memberId = :member2Id AND crm2.isActive = true " +
+           "AND crm1.id != crm2.id")
+    Optional<ChatRoom> findByDogAndTwoActiveMembers(@Param("dogId") Long dogId,
+                                                    @Param("member1Id") Long member1Id,
+                                                    @Param("member2Id") Long member2Id);
 
-    @Query("SELECT cr FROM ChatRoom cr WHERE cr.dog IS NULL AND ((cr.member1 = :member1 AND cr.member2 = :member2) OR (cr.member1 = :member2 AND cr.member2 = :member1))")
-    Optional<ChatRoom> findByTwoMembersAndNullDog(@Param("member1") Member member1, @Param("member2") Member member2);
+    /**
+     * 강아지 정보가 없는 채팅방 중에서 두 멤버가 참여한 채팅방 조회
+     * @param member1Id 첫 번째 멤버 ID
+     * @param member2Id 두 번째 멤버 ID
+     * @return 조건에 맞는 채팅방
+     */
+    @Query("SELECT DISTINCT cr FROM ChatRoom cr " +
+           "JOIN cr.chatRoomMembers crm1 " +
+           "JOIN cr.chatRoomMembers crm2 " +
+           "WHERE cr.dog IS NULL " +
+           "AND crm1.member.memberId = :member1Id AND crm1.isActive = true " +
+           "AND crm2.member.memberId = :member2Id AND crm2.isActive = true " +
+           "AND crm1.id != crm2.id")
+    Optional<ChatRoom> findByTwoActiveMembersAndNullDog(@Param("member1Id") Long member1Id,
+                                                        @Param("member2Id") Long member2Id);
 
-    @Query("""
-        SELECT cr FROM ChatRoom cr
-        LEFT JOIN FETCH cr.member1
-        LEFT JOIN FETCH cr.member2
-        LEFT JOIN FETCH cr.dog
-        WHERE cr.member1.memberId = :memberId OR cr.member2.memberId = :memberId
-        ORDER BY cr.updatedAt DESC
-        """)
-    List<ChatRoom> findMemberChatRoomsWithDetails(@Param("memberId") Long memberId);
+    /**
+     * 두 멤버가 공통으로 참여한 모든 활성 채팅방 조회 (강아지 정보 포함)
+     * @param member1Id 첫 번째 멤버 ID
+     * @param member2Id 두 번째 멤버 ID
+     * @return 공통 참여 채팅방 목록
+     */
+    @Query("SELECT DISTINCT cr FROM ChatRoom cr " +
+           "LEFT JOIN FETCH cr.dog " +
+           "JOIN cr.chatRoomMembers crm1 " +
+           "JOIN cr.chatRoomMembers crm2 " +
+           "WHERE crm1.member.memberId = :member1Id AND crm1.isActive = true " +
+           "AND crm2.member.memberId = :member2Id AND crm2.isActive = true " +
+           "AND crm1.id != crm2.id " +
+           "ORDER BY cr.updatedAt DESC")
+    List<ChatRoom> findCommonActiveChatRooms(@Param("member1Id") Long member1Id,
+                                             @Param("member2Id") Long member2Id);
 
+    /**
+     * 채팅방 상세 정보 조회 (강아지 정보와 활성 멤버 정보 포함)
+     * N+1 문제 방지를 위한 fetch join 사용
+     * @param chatRoomId 채팅방 ID
+     * @return 상세 정보가 포함된 채팅방
+     */
+    @Query("SELECT cr FROM ChatRoom cr " +
+           "LEFT JOIN FETCH cr.dog " +
+           "LEFT JOIN FETCH cr.chatRoomMembers crm " +
+           "LEFT JOIN FETCH crm.member " +
+           "WHERE cr.chatRoomId = :chatRoomId")
+    Optional<ChatRoom> findByIdWithDetails(@Param("chatRoomId") Long chatRoomId);
+
+    /**
+     * 특정 멤버가 참여한 채팅방 목록 조회 (강아지 정보 포함, N+1 방지)
+     * @param memberId 멤버 ID
+     * @return 해당 멤버가 참여한 채팅방 목록
+     */
+    @Query("SELECT DISTINCT cr FROM ChatRoom cr " +
+           "LEFT JOIN FETCH cr.dog " +
+           "JOIN cr.chatRoomMembers crm " +
+           "WHERE crm.member.memberId = :memberId AND crm.isActive = true " +
+           "ORDER BY cr.updatedAt DESC")
+    List<ChatRoom> findMemberActiveChatRoomsWithDog(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/example/petner/domain/chat/repository/MessageRepository.java
+++ b/src/main/java/com/example/petner/domain/chat/repository/MessageRepository.java
@@ -58,4 +58,20 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
         ) latest ON m.chat_room_id = latest.chat_room_id AND m.sent_at = latest.max_sent_at
         """, nativeQuery = true)
     List<Message> findLastMessagesByChatRoomIds(@Param("chatRoomIds") List<Long> chatRoomIds);
+
+    /**
+     * 특정 시간 이후의 메시지 중에서 채팅방별 마지막 메시지 조회
+     * 멤버 가시성을 고려한 마지막 메시지 조회용
+     *
+     * @param chatRoomId 채팅방 ID
+     * @param afterTime 이 시간 이후의 메시지만 조회
+     * @return 조건에 맞는 가장 최근 메시지 (Optional)
+     */
+    @Query("SELECT m FROM Message m " +
+           "WHERE m.chatRoom.chatRoomId = :chatRoomId " +
+           "AND m.sentAt >= :afterTime " +
+           "ORDER BY m.sentAt DESC")
+    List<Message> findByChatRoomIdAndSentAtAfterOrderBySentAtDesc(
+            @Param("chatRoomId") Long chatRoomId,
+            @Param("afterTime") java.time.LocalDateTime afterTime);
 }

--- a/src/main/java/com/example/petner/domain/chat/repository/MessageRepository.java
+++ b/src/main/java/com/example/petner/domain/chat/repository/MessageRepository.java
@@ -33,6 +33,18 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
     List<Message> findByChatRoom_ChatRoomId(Long chatRoomId, Pageable pageable);
 
     /**
+     * 채팅방 ID로 메시지 조회 (N+1 문제 해결용, FETCH JOIN 적용)
+     * @param chatRoomId 채팅방 ID
+     * @param pageable 페이징 정보
+     * @return 발신자 정보가 포함된 메시지 목록
+     */
+    @Query("SELECT m FROM Message m " +
+           "JOIN FETCH m.sender " +
+           "WHERE m.chatRoom.chatRoomId = :chatRoomId " +
+           "ORDER BY m.sentAt ASC")
+    List<Message> findByChatRoomIdWithSender(@Param("chatRoomId") Long chatRoomId, Pageable pageable);
+
+    /**
      * 채팅방 ID로 모든 메시지 조회 (시간순 정렬)
      * ERD Messages 테이블의 chatRoomId(FK) 기준 조회
      *
@@ -40,6 +52,17 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
      * @return 해당 채팅방의 모든 메시지 목록 (오래된 순)
      */
     List<Message> findByChatRoom_ChatRoomIdOrderBySentAtAsc(Long chatRoomId);
+
+    /**
+     * 채팅방 ID로 모든 메시지 조회 (N+1 문제 해결용, FETCH JOIN 적용)
+     * @param chatRoomId 채팅방 ID
+     * @return 발신자 정보가 포함된 모든 메시지 목록
+     */
+    @Query("SELECT m FROM Message m " +
+           "JOIN FETCH m.sender " +
+           "WHERE m.chatRoom.chatRoomId = :chatRoomId " +
+           "ORDER BY m.sentAt ASC")
+    List<Message> findByChatRoomIdWithSenderOrderBySentAtAsc(@Param("chatRoomId") Long chatRoomId);
 
     /**
      * 여러 채팅방의 마지막 메시지를 한 번에 조회 (N+1 문제 해결)

--- a/src/main/java/com/example/petner/domain/chat/repository/MessageRepository.java
+++ b/src/main/java/com/example/petner/domain/chat/repository/MessageRepository.java
@@ -20,7 +20,8 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
      * @param chatRoomId 채팅방 ID
      * @return 가장 최근 메시지 (Optional)
      */
-    Optional<Message> findTopByChatRoom_ChatRoomIdOrderBySentAtDesc(Long chatRoomId);
+    @Query("SELECT m FROM Message m WHERE m.chatRoom.chatRoomId = :chatRoomId ORDER BY m.sentAt DESC LIMIT 1")
+    Optional<Message> findLatestMessageByChatRoomId(@Param("chatRoomId") Long chatRoomId);
 
     /**
      * 채팅방 ID로 메시지 조회 (시간순 정렬, 페이징 지원)
@@ -30,7 +31,8 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
      * @param pageable 페이징 정보
      * @return 해당 채팅방의 메시지 목록
      */
-    List<Message> findByChatRoom_ChatRoomId(Long chatRoomId, Pageable pageable);
+    @Query("SELECT m FROM Message m WHERE m.chatRoom.chatRoomId = :chatRoomId ORDER BY m.sentAt ASC")
+    List<Message> findMessagesByChatRoomId(@Param("chatRoomId") Long chatRoomId, Pageable pageable);
 
     /**
      * 채팅방 ID로 메시지 조회 (N+1 문제 해결용, FETCH JOIN 적용)
@@ -51,7 +53,8 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
      * @param chatRoomId 채팅방 ID
      * @return 해당 채팅방의 모든 메시지 목록 (오래된 순)
      */
-    List<Message> findByChatRoom_ChatRoomIdOrderBySentAtAsc(Long chatRoomId);
+    @Query("SELECT m FROM Message m WHERE m.chatRoom.chatRoomId = :chatRoomId ORDER BY m.sentAt ASC")
+    List<Message> findMessagesByChatRoomIdOrderByTime(@Param("chatRoomId") Long chatRoomId);
 
     /**
      * 채팅방 ID로 모든 메시지 조회 (N+1 문제 해결용, FETCH JOIN 적용)

--- a/src/main/java/com/example/petner/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/example/petner/domain/chat/service/ChatMessageService.java
@@ -58,7 +58,7 @@ public class ChatMessageService {
      * @param messageDto 클라이언트로부터 받은 메시지 DTO
      * @return 저장된 메시지의 응답 DTO
      *
-     * @throws IllegalArgumentException 잘못된 채팅방 ID 또는 발신자 ID
+     * @throws ChatException 잘못된 채팅방 ID 또는 발신자 ID
      * @throws ChatException 채팅 관련 비즈니스 로직 위반
      */
     @Transactional

--- a/src/main/java/com/example/petner/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/example/petner/domain/chat/service/ChatMessageService.java
@@ -43,6 +43,7 @@ public class ChatMessageService {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatRoomMemberRepository chatRoomMemberRepository;
     private final MemberRepository memberRepository;
+    private final ChatRoomMemberManager memberManager;
 
     /**
      * 메시지 저장 처리 (WebSocket 컨트롤러용)
@@ -73,7 +74,7 @@ public class ChatMessageService {
             Member sender = validateSender(messageDto.getSenderId());
 
             // 3. 채팅방 참여자 권한 검증 및 나간 멤버 재입장 처리
-            validateChatRoomParticipantAndRejoinInactiveMembers(chatRoom, sender);
+            memberManager.validateAndReactivateMembers(chatRoom, sender);
 
             // 4. 메시지 엔티티 생성 및 저장
             Message message = createAndSaveMessage(chatRoom, sender, messageDto.getContent());
@@ -120,8 +121,8 @@ public class ChatMessageService {
         Pageable pageable = PageRequest.of(page, size,
                 Sort.by(Sort.Direction.ASC, "sentAt"));
 
-        // 3. 메시지 조회 및 DTO 변환
-        List<Message> messages = messageRepository.findByChatRoom_ChatRoomId(chatRoomId, pageable);
+        // 3. 메시지 조회 및 DTO 변환 (N+1 문제 해결)
+        List<Message> messages = messageRepository.findByChatRoomIdWithSender(chatRoomId, pageable);
 
         List<ChatMessageResponseDto> responseDtos = messages.stream()
                 .map(ChatMessageResponseDto::new)
@@ -143,8 +144,8 @@ public class ChatMessageService {
         // 1. 채팅방 존재 여부 검증
         validateChatRoomExists(chatRoomId);
 
-        // 2. 모든 메시지 조회 (시간순 정렬)
-        List<Message> messages = messageRepository.findByChatRoom_ChatRoomIdOrderBySentAtAsc(chatRoomId);
+        // 2. 모든 메시지 조회 (시간순 정렬, N+1 문제 해결)
+        List<Message> messages = messageRepository.findByChatRoomIdWithSenderOrderBySentAtAsc(chatRoomId);
 
         List<ChatMessageResponseDto> responseDtos = messages.stream()
                 .map(ChatMessageResponseDto::new)
@@ -182,8 +183,8 @@ public class ChatMessageService {
         // 4. 페이징 설정 (시간순 정렬)
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "sentAt"));
 
-        // 5. 메시지 조회 (페이징 적용)
-        List<Message> messages = messageRepository.findByChatRoom_ChatRoomId(chatRoomId, pageable);
+        // 5. 메시지 조회 (페이징 적용, N+1 문제 해결)
+        List<Message> messages = messageRepository.findByChatRoomIdWithSender(chatRoomId, pageable);
 
         // 6. 멤버가 볼 수 있는 메시지만 필터링
         List<ChatMessageResponseDto> visibleMessages = messages.stream()
@@ -218,8 +219,8 @@ public class ChatMessageService {
                 .findByChatRoomAndMember(chatRoom, member)
                 .orElseThrow(() -> new ChatException(ErrorCode.CHAT_UNAUTHORIZED_ACCESS));
 
-        // 4. 모든 메시지 조회 (시간순 정렬)
-        List<Message> allMessages = messageRepository.findByChatRoom_ChatRoomIdOrderBySentAtAsc(chatRoomId);
+        // 4. 모든 메시지 조회 (시간순 정렬, N+1 문제 해결)
+        List<Message> allMessages = messageRepository.findByChatRoomIdWithSenderOrderBySentAtAsc(chatRoomId);
 
         // 5. 멤버가 볼 수 있는 메시지만 필터링
         List<ChatMessageResponseDto> visibleMessages = allMessages.stream()
@@ -268,73 +269,6 @@ public class ChatMessageService {
                 .orElseThrow(() -> new ChatException(ErrorCode.CHAT_MEMBER_NOT_FOUND));
     }
 
-    /**
-     * 채팅방 참여자 권한 검증 및 나간 멤버 재입장 처리
-     *
-     * 동작 흐름:
-     * 1. 발신자가 채팅방의 멤버인지 확인 (활성/비활성 모두 포함)
-     * 2. 발신자가 비활성 상태라면 자동 재입장 처리
-     * 3. 상대방이 비활성 상태라면 자동 재입장 처리 (메시지를 받을 수 있도록)
-     *
-     * @param chatRoom 검증할 채팅방
-     * @param sender 검증할 발신자
-     * @throws ChatException 해당 채팅방의 멤버가 아닌 경우
-     */
-    private void validateChatRoomParticipantAndRejoinInactiveMembers(ChatRoom chatRoom, Member sender) {
-        // 1. 발신자가 이 채팅방의 멤버인지 확인 (활성/비활성 상관없이)
-        boolean isMember = chatRoom.getAllMembers().stream()
-                .anyMatch(chatRoomMember ->
-                    chatRoomMember.getMember().getMemberId().equals(sender.getMemberId()));
-
-        if (!isMember) {
-            log.warn("채팅방 접근 권한 없음 - 채팅방 ID: {}, 발신자 ID: {}",
-                    chatRoom.getChatRoomId(), sender.getMemberId());
-            throw new ChatException(ErrorCode.CHAT_UNAUTHORIZED_ACCESS);
-        }
-
-        // 2. 발신자가 비활성 상태라면 재입장 처리
-        boolean isSenderActive = chatRoomMemberRepository.existsActiveMemberInChatRoom(
-                chatRoom.getChatRoomId(), sender.getMemberId());
-
-        if (!isSenderActive) {
-            log.info("발신자 자동 재입장 처리 - 채팅방 ID: {}, 발신자 ID: {}",
-                    chatRoom.getChatRoomId(), sender.getMemberId());
-            rejoinMemberToChatRoom(chatRoom, sender);
-        }
-
-        // 3. 모든 멤버 중 비활성 상태인 멤버들을 재입장 처리 (메시지를 받을 수 있도록)
-        chatRoom.getAllMembers().stream()
-                .filter(chatRoomMember -> !chatRoomMember.isActive())
-                .forEach(inactiveMember -> {
-                    log.info("비활성 멤버 자동 재입장 처리 - 채팅방 ID: {}, 멤버 ID: {}",
-                            chatRoom.getChatRoomId(), inactiveMember.getMember().getMemberId());
-                    try {
-                        rejoinMemberToChatRoom(chatRoom, inactiveMember.getMember());
-                    } catch (Exception e) {
-                        log.warn("멤버 재입장 실패 - 채팅방 ID: {}, 멤버 ID: {}, 오류: {}",
-                                chatRoom.getChatRoomId(), inactiveMember.getMember().getMemberId(), e.getMessage());
-                    }
-                });
-    }
-
-    /**
-     * 멤버를 채팅방에 재입장시키는 메서드
-     *
-     * @param chatRoom 채팅방 엔티티
-     * @param member 재입장시킬 멤버
-     */
-    private void rejoinMemberToChatRoom(ChatRoom chatRoom, Member member) {
-        ChatRoomMember chatRoomMember = chatRoomMemberRepository
-                .findByChatRoomAndMember(chatRoom, member)
-                .orElseThrow(() -> new ChatException(ErrorCode.CHAT_MEMBER_NOT_FOUND));
-
-        // 멤버를 활성화
-        chatRoomMember.reactivate();
-        chatRoomMemberRepository.save(chatRoomMember);
-
-        log.info("멤버 재입장 완료 - 채팅방 ID: {}, 멤버 ID: {}",
-                chatRoom.getChatRoomId(), member.getMemberId());
-    }
 
     /**
      * 메시지 엔티티 생성 및 저장

--- a/src/main/java/com/example/petner/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/example/petner/domain/chat/service/ChatMessageService.java
@@ -189,14 +189,18 @@ public class ChatMessageService {
 
     /**
      * 채팅방 참여자 권한 검증
+     * ChatRoomMember를 통해 활성 멤버인지 확인
      *
      * @param chatRoom 검증할 채팅방
      * @param sender 검증할 발신자
-     * @throws ChatException 해당 채팅방의 참여자가 아닌 경우
+     * @throws ChatException 해당 채팅방의 활성 참여자가 아닌 경우
      */
     private void validateChatRoomParticipant(ChatRoom chatRoom, Member sender) {
-        if (!chatRoom.getMember1().getMemberId().equals(sender.getMemberId()) &&
-            !chatRoom.getMember2().getMemberId().equals(sender.getMemberId())) {
+        boolean isActiveMember = chatRoom.getActiveMembers().stream()
+                .anyMatch(chatRoomMember ->
+                    chatRoomMember.getMember().getMemberId().equals(sender.getMemberId()));
+
+        if (!isActiveMember) {
             throw new ChatException(ErrorCode.CHAT_UNAUTHORIZED_ACCESS);
         }
     }

--- a/src/main/java/com/example/petner/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/example/petner/domain/chat/service/ChatMessageService.java
@@ -155,6 +155,84 @@ public class ChatMessageService {
     }
 
     /**
+     * 특정 채팅방의 멤버별 가시 메시지 조회 (페이징)
+     * 멤버의 입장/나가기 이력에 따라 볼 수 있는 메시지만 필터링
+     *
+     * @param chatRoomId 채팅방 고유 식별자
+     * @param memberId 조회 요청하는 멤버 ID
+     * @param page 페이지 번호 (0부터 시작)
+     * @param size 페이지 크기
+     * @return 해당 멤버가 볼 수 있는 메시지 응답 DTO 리스트
+     */
+    public List<ChatMessageResponseDto> getVisibleMessagesForMember(Long chatRoomId, Long memberId, int page, int size) {
+        log.info("멤버별 가시 메시지 조회 (페이징) - 채팅방 ID: {}, 멤버 ID: {}, 페이지: {}, 크기: {}",
+                chatRoomId, memberId, page, size);
+
+        // 1. 채팅방 존재 여부 검증
+        ChatRoom chatRoom = validateChatRoom(chatRoomId);
+
+        // 2. 멤버 검증
+        Member member = validateSender(memberId);
+
+        // 3. 멤버의 채팅방 참여 이력 조회
+        ChatRoomMember chatRoomMember = chatRoomMemberRepository
+                .findByChatRoomAndMember(chatRoom, member)
+                .orElseThrow(() -> new ChatException(ErrorCode.CHAT_UNAUTHORIZED_ACCESS));
+
+        // 4. 페이징 설정 (시간순 정렬)
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "sentAt"));
+
+        // 5. 메시지 조회 (페이징 적용)
+        List<Message> messages = messageRepository.findByChatRoom_ChatRoomId(chatRoomId, pageable);
+
+        // 6. 멤버가 볼 수 있는 메시지만 필터링
+        List<ChatMessageResponseDto> visibleMessages = messages.stream()
+                .filter(message -> chatRoomMember.canSeeMessage(message.getSentAt()))
+                .map(ChatMessageResponseDto::new)
+                .toList();
+
+        log.info("멤버별 가시 메시지 조회 완료 (페이징) - 조회: {}, 가시: {} 개 메시지",
+                messages.size(), visibleMessages.size());
+        return visibleMessages;
+    }
+
+    /**
+     * 특정 채팅방의 멤버별 가시 메시지 조회 (페이징 없음)
+     * 멤버의 입장/나가기 이력에 따라 볼 수 있는 메시지만 필터링
+     *
+     * @param chatRoomId 채팅방 고유 식별자
+     * @param memberId 조회 요청하는 멤버 ID
+     * @return 해당 멤버가 볼 수 있는 메시지 응답 DTO 리스트
+     */
+    public List<ChatMessageResponseDto> getVisibleMessagesForMember(Long chatRoomId, Long memberId) {
+        log.info("멤버별 가시 메시지 조회 - 채팅방 ID: {}, 멤버 ID: {}", chatRoomId, memberId);
+
+        // 1. 채팅방 존재 여부 검증
+        ChatRoom chatRoom = validateChatRoom(chatRoomId);
+
+        // 2. 멤버 검증
+        Member member = validateSender(memberId);
+
+        // 3. 멤버의 채팅방 참여 이력 조회
+        ChatRoomMember chatRoomMember = chatRoomMemberRepository
+                .findByChatRoomAndMember(chatRoom, member)
+                .orElseThrow(() -> new ChatException(ErrorCode.CHAT_UNAUTHORIZED_ACCESS));
+
+        // 4. 모든 메시지 조회 (시간순 정렬)
+        List<Message> allMessages = messageRepository.findByChatRoom_ChatRoomIdOrderBySentAtAsc(chatRoomId);
+
+        // 5. 멤버가 볼 수 있는 메시지만 필터링
+        List<ChatMessageResponseDto> visibleMessages = allMessages.stream()
+                .filter(message -> chatRoomMember.canSeeMessage(message.getSentAt()))
+                .map(ChatMessageResponseDto::new)
+                .toList();
+
+        log.info("멤버별 가시 메시지 조회 완료 - 전체: {}, 가시: {} 개 메시지",
+                allMessages.size(), visibleMessages.size());
+        return visibleMessages;
+    }
+
+    /**
      * 채팅방 존재 여부 검증 (조회용)
      *
      * @param chatRoomId 검증할 채팅방 ID

--- a/src/main/java/com/example/petner/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/example/petner/domain/chat/service/ChatMessageService.java
@@ -3,8 +3,10 @@ package com.example.petner.domain.chat.service;
 import com.example.petner.domain.chat.dto.request.ChatMessageRequestDto;
 import com.example.petner.domain.chat.dto.response.ChatMessageResponseDto;
 import com.example.petner.domain.chat.entity.ChatRoom;
+import com.example.petner.domain.chat.entity.ChatRoomMember;
 import com.example.petner.domain.chat.entity.Message;
 import com.example.petner.domain.chat.repository.ChatRoomRepository;
+import com.example.petner.domain.chat.repository.ChatRoomMemberRepository;
 import com.example.petner.domain.chat.repository.MessageRepository;
 import com.example.petner.domain.member.entity.Member;
 import com.example.petner.domain.member.repository.MemberRepository;
@@ -39,6 +41,7 @@ public class ChatMessageService {
 
     private final MessageRepository messageRepository;
     private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
     private final MemberRepository memberRepository;
 
     /**
@@ -69,8 +72,8 @@ public class ChatMessageService {
             // 2. 발신자 검증
             Member sender = validateSender(messageDto.getSenderId());
 
-            // 3. 채팅방 참여자 권한 검증
-            validateChatRoomParticipant(chatRoom, sender);
+            // 3. 채팅방 참여자 권한 검증 및 나간 멤버 재입장 처리
+            validateChatRoomParticipantAndRejoinInactiveMembers(chatRoom, sender);
 
             // 4. 메시지 엔티티 생성 및 저장
             Message message = createAndSaveMessage(chatRoom, sender, messageDto.getContent());
@@ -188,21 +191,71 @@ public class ChatMessageService {
     }
 
     /**
-     * 채팅방 참여자 권한 검증
-     * ChatRoomMember를 통해 활성 멤버인지 확인
+     * 채팅방 참여자 권한 검증 및 나간 멤버 재입장 처리
+     *
+     * 동작 흐름:
+     * 1. 발신자가 채팅방의 멤버인지 확인 (활성/비활성 모두 포함)
+     * 2. 발신자가 비활성 상태라면 자동 재입장 처리
+     * 3. 상대방이 비활성 상태라면 자동 재입장 처리 (메시지를 받을 수 있도록)
      *
      * @param chatRoom 검증할 채팅방
      * @param sender 검증할 발신자
-     * @throws ChatException 해당 채팅방의 활성 참여자가 아닌 경우
+     * @throws ChatException 해당 채팅방의 멤버가 아닌 경우
      */
-    private void validateChatRoomParticipant(ChatRoom chatRoom, Member sender) {
-        boolean isActiveMember = chatRoom.getActiveMembers().stream()
+    private void validateChatRoomParticipantAndRejoinInactiveMembers(ChatRoom chatRoom, Member sender) {
+        // 1. 발신자가 이 채팅방의 멤버인지 확인 (활성/비활성 상관없이)
+        boolean isMember = chatRoom.getAllMembers().stream()
                 .anyMatch(chatRoomMember ->
                     chatRoomMember.getMember().getMemberId().equals(sender.getMemberId()));
 
-        if (!isActiveMember) {
+        if (!isMember) {
+            log.warn("채팅방 접근 권한 없음 - 채팅방 ID: {}, 발신자 ID: {}",
+                    chatRoom.getChatRoomId(), sender.getMemberId());
             throw new ChatException(ErrorCode.CHAT_UNAUTHORIZED_ACCESS);
         }
+
+        // 2. 발신자가 비활성 상태라면 재입장 처리
+        boolean isSenderActive = chatRoomMemberRepository.existsActiveMemberInChatRoom(
+                chatRoom.getChatRoomId(), sender.getMemberId());
+
+        if (!isSenderActive) {
+            log.info("발신자 자동 재입장 처리 - 채팅방 ID: {}, 발신자 ID: {}",
+                    chatRoom.getChatRoomId(), sender.getMemberId());
+            rejoinMemberToChatRoom(chatRoom, sender);
+        }
+
+        // 3. 모든 멤버 중 비활성 상태인 멤버들을 재입장 처리 (메시지를 받을 수 있도록)
+        chatRoom.getAllMembers().stream()
+                .filter(chatRoomMember -> !chatRoomMember.isActive())
+                .forEach(inactiveMember -> {
+                    log.info("비활성 멤버 자동 재입장 처리 - 채팅방 ID: {}, 멤버 ID: {}",
+                            chatRoom.getChatRoomId(), inactiveMember.getMember().getMemberId());
+                    try {
+                        rejoinMemberToChatRoom(chatRoom, inactiveMember.getMember());
+                    } catch (Exception e) {
+                        log.warn("멤버 재입장 실패 - 채팅방 ID: {}, 멤버 ID: {}, 오류: {}",
+                                chatRoom.getChatRoomId(), inactiveMember.getMember().getMemberId(), e.getMessage());
+                    }
+                });
+    }
+
+    /**
+     * 멤버를 채팅방에 재입장시키는 메서드
+     *
+     * @param chatRoom 채팅방 엔티티
+     * @param member 재입장시킬 멤버
+     */
+    private void rejoinMemberToChatRoom(ChatRoom chatRoom, Member member) {
+        ChatRoomMember chatRoomMember = chatRoomMemberRepository
+                .findByChatRoomAndMember(chatRoom, member)
+                .orElseThrow(() -> new ChatException(ErrorCode.CHAT_MEMBER_NOT_FOUND));
+
+        // 멤버를 활성화
+        chatRoomMember.reactivate();
+        chatRoomMemberRepository.save(chatRoomMember);
+
+        log.info("멤버 재입장 완료 - 채팅방 ID: {}, 멤버 ID: {}",
+                chatRoom.getChatRoomId(), member.getMemberId());
     }
 
     /**

--- a/src/main/java/com/example/petner/domain/chat/service/ChatRoomDtoConverter.java
+++ b/src/main/java/com/example/petner/domain/chat/service/ChatRoomDtoConverter.java
@@ -68,8 +68,13 @@ public class ChatRoomDtoConverter {
         ChatRoomListResponseDto.DogInfo dogInfo = createDogInfo(chatRoom);
 
         // ✅ N+1 문제 해결 - 미리 조회된 메시지 사용 (추가 쿼리 없음)
-        String lastMessageContent = lastMessage != null ? lastMessage.getContent() : "";
+        String lastMessageContent = lastMessage != null ? lastMessage.getContent() : "아직 메시지가 없습니다";
         var lastMessageSentAt = lastMessage != null ? lastMessage.getSentAt() : chatRoom.getCreatedAt();
+
+        // 디버깅: DTO 변환 단계에서 메시지 정보 출력
+        // System.out.println("DEBUG [DTO Converter]: 채팅방 " + chatRoom.getChatRoomId() +
+        //         " | lastMessage: " + (lastMessage != null ? lastMessage.getMessageId() : "null") +
+        //         " | content: '" + lastMessageContent + "'");
 
         return new ChatRoomListResponseDto(
                 chatRoom.getChatRoomId(),

--- a/src/main/java/com/example/petner/domain/chat/service/ChatRoomDtoConverter.java
+++ b/src/main/java/com/example/petner/domain/chat/service/ChatRoomDtoConverter.java
@@ -80,9 +80,20 @@ public class ChatRoomDtoConverter {
         );
     }
 
+    /**
+     * 현재 사용자가 아닌 다른 멤버 찾기
+     * ChatRoomMember를 통해 활성 상태의 다른 멤버를 조회
+     *
+     * @param chatRoom 채팅방
+     * @param currentMemberId 현재 사용자 ID
+     * @return 다른 멤버 정보
+     */
     private Member determineOtherMember(ChatRoom chatRoom, Long currentMemberId) {
-        return chatRoom.getMember1().getMemberId().equals(currentMemberId)
-                ? chatRoom.getMember2() : chatRoom.getMember1();
+        return chatRoom.getActiveMembers().stream()
+                .map(chatRoomMember -> chatRoomMember.getMember())
+                .filter(member -> !member.getMemberId().equals(currentMemberId))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("채팅방에 다른 활성 멤버가 없습니다."));
     }
 
     private ChatRoomListResponseDto.DogInfo createDogInfo(ChatRoom chatRoom) {

--- a/src/main/java/com/example/petner/domain/chat/service/ChatRoomDtoConverter.java
+++ b/src/main/java/com/example/petner/domain/chat/service/ChatRoomDtoConverter.java
@@ -82,18 +82,18 @@ public class ChatRoomDtoConverter {
 
     /**
      * 현재 사용자가 아닌 다른 멤버 찾기
-     * ChatRoomMember를 통해 활성 상태의 다른 멤버를 조회
+     * ChatRoomMember를 통해 활성/비활성 상관없이 다른 멤버를 조회
      *
      * @param chatRoom 채팅방
      * @param currentMemberId 현재 사용자 ID
      * @return 다른 멤버 정보
      */
     private Member determineOtherMember(ChatRoom chatRoom, Long currentMemberId) {
-        return chatRoom.getActiveMembers().stream()
+        return chatRoom.getChatRoomMembers().stream()
                 .map(chatRoomMember -> chatRoomMember.getMember())
                 .filter(member -> !member.getMemberId().equals(currentMemberId))
                 .findFirst()
-                .orElseThrow(() -> new IllegalStateException("채팅방에 다른 활성 멤버가 없습니다."));
+                .orElseThrow(() -> new IllegalStateException("채팅방에 다른 멤버가 없습니다."));
     }
 
     private ChatRoomListResponseDto.DogInfo createDogInfo(ChatRoom chatRoom) {

--- a/src/main/java/com/example/petner/domain/chat/service/ChatRoomDtoConverter.java
+++ b/src/main/java/com/example/petner/domain/chat/service/ChatRoomDtoConverter.java
@@ -35,7 +35,7 @@ public class ChatRoomDtoConverter {
         ChatRoomListResponseDto.DogInfo dogInfo = createDogInfo(chatRoom);
 
         // 🚨 N+1 문제 발생 지점 - 개별 쿼리 실행
-        var lastMessage = messageRepository.findTopByChatRoom_ChatRoomIdOrderBySentAtDesc(chatRoom.getChatRoomId());
+        var lastMessage = messageRepository.findLatestMessageByChatRoomId(chatRoom.getChatRoomId());
         String lastMessageContent = lastMessage.map(message -> message.getContent()).orElse("");
         var lastMessageSentAt = lastMessage.map(message -> message.getSentAt()).orElse(chatRoom.getCreatedAt());
 

--- a/src/main/java/com/example/petner/domain/chat/service/ChatRoomDtoConverter.java
+++ b/src/main/java/com/example/petner/domain/chat/service/ChatRoomDtoConverter.java
@@ -5,6 +5,8 @@ import com.example.petner.domain.chat.entity.ChatRoom;
 import com.example.petner.domain.chat.entity.Message;
 import com.example.petner.domain.chat.repository.MessageRepository;
 import com.example.petner.domain.member.entity.Member;
+import com.example.petner.global.exception.ErrorCode;
+import com.example.petner.global.exception.customException.ChatException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -98,7 +100,7 @@ public class ChatRoomDtoConverter {
                 .map(chatRoomMember -> chatRoomMember.getMember())
                 .filter(member -> !member.getMemberId().equals(currentMemberId))
                 .findFirst()
-                .orElseThrow(() -> new IllegalStateException("채팅방에 다른 멤버가 없습니다."));
+                .orElseThrow(() -> new ChatException(ErrorCode.CHAT_INVALID_REQUEST));
     }
 
     private ChatRoomListResponseDto.DogInfo createDogInfo(ChatRoom chatRoom) {

--- a/src/main/java/com/example/petner/domain/chat/service/ChatRoomDuplicateChecker.java
+++ b/src/main/java/com/example/petner/domain/chat/service/ChatRoomDuplicateChecker.java
@@ -3,15 +3,19 @@ package com.example.petner.domain.chat.service;
 import com.example.petner.domain.chat.entity.ChatRoom;
 import com.example.petner.domain.chat.repository.ChatRoomRepository;
 import com.example.petner.domain.dog.entity.Dog;
-import com.example.petner.domain.member.entity.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
  * 채팅방 중복 체크 로직을 담당하는 컴포넌트
  * Single Responsibility Principle을 적용하여 중복 체크 책임만 담당
+ *
+ * 변경사항:
+ * - member1, member2 대신 member ID를 사용
+ * - ChatRoomMember를 통한 멤버 관계 확인
  */
 @Component
 @RequiredArgsConstructor
@@ -24,17 +28,41 @@ public class ChatRoomDuplicateChecker {
      * 강아지가 있는 경우와 없는 경우를 구분하여 적절한 중복 체크 수행
      *
      * @param dog 강아지 (nullable)
-     * @param member1 첫 번째 멤버
-     * @param member2 두 번째 멤버
+     * @param member1Id 첫 번째 멤버 ID
+     * @param member2Id 두 번째 멤버 ID
      * @return 기존 채팅방 (없으면 Optional.empty())
      */
-    public Optional<ChatRoom> findExistingChatRoom(Dog dog, Member member1, Member member2) {
+    public Optional<ChatRoom> findExistingChatRoom(Dog dog, Long member1Id, Long member2Id) {
         if (dog != null) {
             // 강아지가 지정된 경우: 동일한 강아지 + 두 멤버 조합 체크
-            return chatRoomRepository.findByDogAndTwoMembers(dog, member1, member2);
+            return chatRoomRepository.findByDogAndTwoActiveMembers(dog.getDogId(), member1Id, member2Id);
         } else {
             // 일반 채팅방인 경우: 강아지가 null이고 두 멤버가 같은 채팅방 체크
-            return chatRoomRepository.findByTwoMembersAndNullDog(member1, member2);
+            return chatRoomRepository.findByTwoActiveMembersAndNullDog(member1Id, member2Id);
         }
+    }
+
+    /**
+     * 두 멤버가 공통으로 참여한 모든 채팅방 조회
+     * 동일한 사용자들이 여러 채팅방에 참여했는지 확인할 때 사용
+     *
+     * @param member1Id 첫 번째 멤버 ID
+     * @param member2Id 두 번째 멤버 ID
+     * @return 공통 참여 채팅방 목록
+     */
+    public List<ChatRoom> findAllCommonChatRooms(Long member1Id, Long member2Id) {
+        return chatRoomRepository.findCommonActiveChatRooms(member1Id, member2Id);
+    }
+
+    /**
+     * 특정 강아지와 관련된 채팅방에서 두 멤버가 이미 채팅 중인지 확인
+     *
+     * @param dog 강아지
+     * @param member1Id 첫 번째 멤버 ID
+     * @param member2Id 두 번째 멤버 ID
+     * @return 중복 여부
+     */
+    public boolean isDuplicateChatRoom(Dog dog, Long member1Id, Long member2Id) {
+        return findExistingChatRoom(dog, member1Id, member2Id).isPresent();
     }
 }

--- a/src/main/java/com/example/petner/domain/chat/service/ChatRoomDuplicateChecker.java
+++ b/src/main/java/com/example/petner/domain/chat/service/ChatRoomDuplicateChecker.java
@@ -24,7 +24,7 @@ public class ChatRoomDuplicateChecker {
     private final ChatRoomRepository chatRoomRepository;
 
     /**
-     * 기존 채팅방 존재 여부 확인
+     * 기존 채팅방 존재 여부 확인 (활성/비활성 상관없이)
      * 강아지가 있는 경우와 없는 경우를 구분하여 적절한 중복 체크 수행
      *
      * @param dog 강아지 (nullable)
@@ -34,11 +34,11 @@ public class ChatRoomDuplicateChecker {
      */
     public Optional<ChatRoom> findExistingChatRoom(Dog dog, Long member1Id, Long member2Id) {
         if (dog != null) {
-            // 강아지가 지정된 경우: 동일한 강아지 + 두 멤버 조합 체크
-            return chatRoomRepository.findByDogAndTwoActiveMembers(dog.getDogId(), member1Id, member2Id);
+            // 강아지가 지정된 경우: 동일한 강아지 + 두 멤버 조합 체크 (활성/비활성 무관)
+            return chatRoomRepository.findByDogAndTwoMembers(dog.getDogId(), member1Id, member2Id);
         } else {
-            // 일반 채팅방인 경우: 강아지가 null이고 두 멤버가 같은 채팅방 체크
-            return chatRoomRepository.findByTwoActiveMembersAndNullDog(member1Id, member2Id);
+            // 일반 채팅방인 경우: 강아지가 null이고 두 멤버가 같은 채팅방 체크 (활성/비활성 무관)
+            return chatRoomRepository.findByTwoMembersAndNullDog(member1Id, member2Id);
         }
     }
 

--- a/src/main/java/com/example/petner/domain/chat/service/ChatRoomMemberManager.java
+++ b/src/main/java/com/example/petner/domain/chat/service/ChatRoomMemberManager.java
@@ -1,0 +1,123 @@
+package com.example.petner.domain.chat.service;
+
+import com.example.petner.domain.chat.entity.ChatRoom;
+import com.example.petner.domain.chat.entity.ChatRoomMember;
+import com.example.petner.domain.chat.repository.ChatRoomMemberRepository;
+import com.example.petner.domain.member.entity.Member;
+import com.example.petner.global.exception.ErrorCode;
+import com.example.petner.global.exception.customException.ChatException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 채팅방 멤버 관리 전담 서비스
+ * Single Responsibility Principle을 적용하여 멤버 상태 관리 책임만 담당
+ *
+ * 책임:
+ * - 채팅방 멤버 활성화/비활성화 처리
+ * - 멤버 재입장 로직 관리
+ * - 멤버 권한 검증
+ *
+ * @author VIBE CODING Team
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class ChatRoomMemberManager {
+
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+
+    /**
+     * 채팅방 참여자 권한 검증 및 비활성 멤버 자동 재입장 처리
+     *
+     * 동작 흐름:
+     * 1. 발신자가 채팅방의 멤버인지 확인 (활성/비활성 모두 포함)
+     * 2. 발신자가 비활성 상태라면 자동 재입장 처리
+     * 3. 상대방이 비활성 상태라면 자동 재입장 처리 (메시지를 받을 수 있도록)
+     *
+     * @param chatRoom 검증할 채팅방
+     * @param sender 검증할 발신자
+     * @throws ChatException 해당 채팅방의 멤버가 아닌 경우
+     */
+    @Transactional
+    public void validateAndReactivateMembers(ChatRoom chatRoom, Member sender) {
+        // 1. 발신자가 이 채팅방의 멤버인지 확인 (활성/비활성 상관없이)
+        boolean isMember = chatRoom.getAllMembers().stream()
+                .anyMatch(chatRoomMember ->
+                    chatRoomMember.getMember().getMemberId().equals(sender.getMemberId()));
+
+        if (!isMember) {
+            log.warn("채팅방 접근 권한 없음 - 채팅방 ID: {}, 발신자 ID: {}",
+                    chatRoom.getChatRoomId(), sender.getMemberId());
+            throw new ChatException(ErrorCode.CHAT_UNAUTHORIZED_ACCESS);
+        }
+
+        // 2. 발신자가 비활성 상태라면 재입장 처리
+        boolean isSenderActive = chatRoomMemberRepository.existsActiveMemberInChatRoom(
+                chatRoom.getChatRoomId(), sender.getMemberId());
+
+        if (!isSenderActive) {
+            log.info("발신자 자동 재입장 처리 - 채팅방 ID: {}, 발신자 ID: {}",
+                    chatRoom.getChatRoomId(), sender.getMemberId());
+            reactivateMember(chatRoom, sender);
+        }
+
+        // 3. 모든 멤버 중 비활성 상태인 멤버들을 재입장 처리 (메시지를 받을 수 있도록)
+        chatRoom.getAllMembers().stream()
+                .filter(chatRoomMember -> !chatRoomMember.isActive())
+                .forEach(inactiveMember -> {
+                    log.info("비활성 멤버 자동 재입장 처리 - 채팅방 ID: {}, 멤버 ID: {}",
+                            chatRoom.getChatRoomId(), inactiveMember.getMember().getMemberId());
+                    try {
+                        reactivateMember(chatRoom, inactiveMember.getMember());
+                    } catch (Exception e) {
+                        log.warn("멤버 재입장 실패 - 채팅방 ID: {}, 멤버 ID: {}, 오류: {}",
+                                chatRoom.getChatRoomId(), inactiveMember.getMember().getMemberId(), e.getMessage());
+                    }
+                });
+    }
+
+    /**
+     * 멤버를 채팅방에 재입장시키는 메서드
+     *
+     * @param chatRoom 채팅방 엔티티
+     * @param member 재입장시킬 멤버
+     */
+    @Transactional
+    public void reactivateMember(ChatRoom chatRoom, Member member) {
+        ChatRoomMember chatRoomMember = chatRoomMemberRepository
+                .findByChatRoomAndMember(chatRoom, member)
+                .orElseThrow(() -> new ChatException(ErrorCode.CHAT_MEMBER_NOT_FOUND));
+
+        // 멤버를 활성화
+        chatRoomMember.reactivate();
+        chatRoomMemberRepository.save(chatRoomMember);
+
+        log.info("멤버 재입장 완료 - 채팅방 ID: {}, 멤버 ID: {}",
+                chatRoom.getChatRoomId(), member.getMemberId());
+    }
+
+    /**
+     * 특정 멤버가 채팅방에서 활성 상태인지 확인
+     *
+     * @param chatRoomId 채팅방 ID
+     * @param memberId 멤버 ID
+     * @return 활성 상태 여부
+     */
+    public boolean isActiveMemberInChatRoom(Long chatRoomId, Long memberId) {
+        return chatRoomMemberRepository.existsActiveMemberInChatRoom(chatRoomId, memberId);
+    }
+
+    /**
+     * 채팅방의 활성 멤버 수 조회
+     *
+     * @param chatRoomId 채팅방 ID
+     * @return 활성 멤버 수
+     */
+    public long getActiveMemberCount(Long chatRoomId) {
+        return chatRoomMemberRepository.countActiveMembersByChatRoomId(chatRoomId);
+    }
+}

--- a/src/main/java/com/example/petner/domain/chat/service/ChatRoomQueryService.java
+++ b/src/main/java/com/example/petner/domain/chat/service/ChatRoomQueryService.java
@@ -2,7 +2,9 @@ package com.example.petner.domain.chat.service;
 
 import com.example.petner.domain.chat.dto.response.ChatRoomListResponseDto;
 import com.example.petner.domain.chat.entity.ChatRoom;
+import com.example.petner.domain.chat.entity.ChatRoomMember;
 import com.example.petner.domain.chat.entity.Message;
+import com.example.petner.domain.chat.repository.ChatRoomMemberRepository;
 import com.example.petner.domain.chat.repository.ChatRoomRepository;
 import com.example.petner.domain.chat.repository.MessageRepository;
 import com.example.petner.domain.member.entity.Member;
@@ -20,6 +22,11 @@ import java.util.stream.Collectors;
 /**
  * 채팅방 조회 전용 서비스
  * Single Responsibility Principle을 적용하여 조회 책임만 담당
+ *
+ * 변경사항:
+ * - ChatRoomMember를 통한 채팅방 목록 조회
+ * - 활성 상태의 채팅방만 조회
+ * - N+1 문제 방지를 위한 최적화된 쿼리 사용
  */
 @Service
 @RequiredArgsConstructor
@@ -27,6 +34,7 @@ import java.util.stream.Collectors;
 public class ChatRoomQueryService {
 
     private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
     private final MemberRepository memberRepository;
     private final MessageRepository messageRepository;
     private final ChatRoomDtoConverter dtoConverter;
@@ -35,41 +43,47 @@ public class ChatRoomQueryService {
      * 특정 사용자의 전체 채팅방 목록 조회 (N+1 문제 해결)
      *
      * 성능 최적화:
-     * 1. 채팅방 목록 조회 (1번 쿼리, FETCH JOIN 적용)
+     * 1. 활성 채팅방 멤버 목록 조회 (1번 쿼리, FETCH JOIN 적용)
      * 2. 모든 채팅방의 마지막 메시지 배치 조회 (1번 쿼리)
      * 총 2번 쿼리로 N+1 문제 완전 해결
      *
      * @param memberId 조회할 사용자 ID
-     * @return 사용자가 참여 중인 채팅방 목록
+     * @return 사용자가 활성 참여 중인 채팅방 목록
      */
     public List<ChatRoomListResponseDto> getMemberChatRooms(Long memberId) {
         // 1. 사용자 존재 여부 검증
-        Member member = memberRepository.findById(memberId)
+        memberRepository.findById(memberId)
                 .orElseThrow(() -> new ChatException(ErrorCode.CHAT_MEMBER_NOT_FOUND));
 
-        // 2. 채팅방 목록 조회 (FETCH JOIN으로 N+1 방지)
-        List<ChatRoom> chatRooms = chatRoomRepository.findMemberChatRoomsWithDetails(memberId);
+        // 2. 활성 채팅방 멤버 목록 조회 (FETCH JOIN으로 N+1 방지)
+        List<ChatRoomMember> activeChatRoomMembers = chatRoomMemberRepository
+                .findActiveChatRoomsByMemberId(memberId);
 
-        if (chatRooms.isEmpty()) {
+        if (activeChatRoomMembers.isEmpty()) {
             return List.of();
         }
 
-        // 3. 채팅방 ID 리스트 추출
+        // 3. 채팅방 목록 추출
+        List<ChatRoom> chatRooms = activeChatRoomMembers.stream()
+                .map(ChatRoomMember::getChatRoom)
+                .collect(Collectors.toList());
+
+        // 4. 채팅방 ID 리스트 추출
         List<Long> chatRoomIds = chatRooms.stream()
                 .map(ChatRoom::getChatRoomId)
                 .collect(Collectors.toList());
 
-        // 4. 모든 채팅방의 마지막 메시지를 한 번에 조회 (배치 쿼리)
+        // 5. 모든 채팅방의 마지막 메시지를 한 번에 조회 (배치 쿼리)
         List<Message> lastMessages = messageRepository.findLastMessagesByChatRoomIds(chatRoomIds);
 
-        // 5. 채팅방 ID를 키로 하는 마지막 메시지 맵 생성
+        // 6. 채팅방 ID를 키로 하는 마지막 메시지 맵 생성
         Map<Long, Message> lastMessageMap = lastMessages.stream()
                 .collect(Collectors.toMap(
                         message -> message.getChatRoom().getChatRoomId(),
                         message -> message
                 ));
 
-        // 6. DTO 변환 (추가 쿼리 없이 메모리에서 처리)
+        // 7. DTO 변환 (추가 쿼리 없이 메모리에서 처리)
         return chatRooms.stream()
                 .map(chatRoom -> dtoConverter.convertToChatRoomListResponseDto(
                         chatRoom,
@@ -77,5 +91,50 @@ public class ChatRoomQueryService {
                         lastMessageMap.get(chatRoom.getChatRoomId())
                 ))
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * 채팅방 상세 정보 조회
+     * 멤버 접근 권한 확인 및 N+1 문제 방지
+     *
+     * @param chatRoomId 채팅방 ID
+     * @param memberId 조회 요청 멤버 ID
+     * @return 채팅방 상세 정보
+     */
+    public ChatRoom getChatRoomDetails(Long chatRoomId, Long memberId) {
+        // 1. 멤버의 채팅방 접근 권한 확인
+        boolean hasAccess = chatRoomMemberRepository
+                .existsActiveMemberInChatRoom(chatRoomId, memberId);
+
+        if (!hasAccess) {
+            throw new ChatException(ErrorCode.CHAT_ROOM_ACCESS_DENIED);
+        }
+
+        // 2. 채팅방 상세 정보 조회 (N+1 방지)
+        return chatRoomRepository.findByIdWithDetails(chatRoomId)
+                .orElseThrow(() -> new ChatException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+    }
+
+    /**
+     * 두 멤버가 공통으로 참여한 채팅방 목록 조회
+     * 관리자 기능 또는 특별한 비즈니스 로직에서 사용
+     *
+     * @param member1Id 첫 번째 멤버 ID
+     * @param member2Id 두 번째 멤버 ID
+     * @return 공통 참여 채팅방 목록
+     */
+    public List<ChatRoom> getCommonChatRooms(Long member1Id, Long member2Id) {
+        return chatRoomRepository.findCommonActiveChatRooms(member1Id, member2Id);
+    }
+
+    /**
+     * 채팅방의 활성 멤버 수 조회
+     * 채팅방 관리 및 통계 정보 제공
+     *
+     * @param chatRoomId 채팅방 ID
+     * @return 활성 멤버 수
+     */
+    public long getActiveMemberCount(Long chatRoomId) {
+        return chatRoomMemberRepository.countActiveMembersByChatRoomId(chatRoomId);
     }
 }

--- a/src/main/java/com/example/petner/domain/chat/service/ChatRoomQueryService.java
+++ b/src/main/java/com/example/petner/domain/chat/service/ChatRoomQueryService.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -63,32 +64,64 @@ public class ChatRoomQueryService {
             return List.of();
         }
 
-        // 3. 채팅방 목록 추출
-        List<ChatRoom> chatRooms = activeChatRoomMembers.stream()
+        // 3. ChatRoomMember를 채팅방 ID별로 그룹화 (중복 제거)
+        Map<Long, ChatRoomMember> chatRoomMemberMap = activeChatRoomMembers.stream()
+                .collect(Collectors.toMap(
+                        crm -> crm.getChatRoom().getChatRoomId(),
+                        crm -> crm,
+                        (existing, replacement) -> existing // 중복 시 첫 번째 것 유지
+                ));
+
+        // 4. 채팅방 목록 추출
+        List<ChatRoom> chatRooms = chatRoomMemberMap.values().stream()
                 .map(ChatRoomMember::getChatRoom)
                 .collect(Collectors.toList());
 
-        // 4. 채팅방 ID 리스트 추출
-        List<Long> chatRoomIds = chatRooms.stream()
-                .map(ChatRoom::getChatRoomId)
-                .collect(Collectors.toList());
+        // 5. 각 채팅방별로 멤버가 볼 수 있는 마지막 메시지 조회 (null 안전 처리)
+        Map<Long, Message> visibleLastMessageMap = new HashMap<>();
 
-        // 5. 모든 채팅방의 마지막 메시지를 한 번에 조회 (배치 쿼리)
-        List<Message> lastMessages = messageRepository.findLastMessagesByChatRoomIds(chatRoomIds);
+        for (Map.Entry<Long, ChatRoomMember> entry : chatRoomMemberMap.entrySet()) {
+            Long chatRoomId = entry.getKey();
+            ChatRoomMember crm = entry.getValue();
 
-        // 6. 채팅방 ID를 키로 하는 마지막 메시지 맵 생성
-        Map<Long, Message> lastMessageMap = lastMessages.stream()
-                .collect(Collectors.toMap(
-                        message -> message.getChatRoom().getChatRoomId(),
-                        message -> message
-                ));
+            Message lastMessage = null;
+            try {
+                if (crm.getJoinedAt() != null) {
+                    // 입장 시간 이후의 메시지 중 가장 최근 메시지 조회
+                    List<Message> messages = messageRepository.findByChatRoomIdAndSentAtAfterOrderBySentAtDesc(
+                            chatRoomId, crm.getJoinedAt());
+                    lastMessage = messages.isEmpty() ? null : messages.get(0);
 
-        // 7. DTO 변환 (추가 쿼리 없이 메모리에서 처리)
+                    // 디버깅용 로그
+                    // if (lastMessage == null) {
+                    //     System.out.println("DEBUG: 채팅방 " + chatRoomId + "에서 joinedAt(" + crm.getJoinedAt() + ") 이후 메시지 없음");
+                    // }
+                } else {
+                    // joinedAt이 null이면 모든 메시지 볼 수 있음
+                    lastMessage = messageRepository.findTopByChatRoom_ChatRoomIdOrderBySentAtDesc(
+                            chatRoomId).orElse(null);
+
+                    // 디버깅용 로그
+                    // if (lastMessage == null) {
+                    //     System.out.println("DEBUG: 채팅방 " + chatRoomId + "에 메시지가 전혀 없음 (joinedAt=null)");
+                    // }
+                }
+            } catch (Exception e) {
+                // 메시지 조회 실패 시 null 처리 (로그는 남기지만 에러는 무시)
+                // System.out.println("DEBUG: 채팅방 " + chatRoomId + " 메시지 조회 실패: " + e.getMessage());
+                lastMessage = null;
+            }
+
+            // null이어도 Map에 추가 (DTO 변환에서 처리)
+            visibleLastMessageMap.put(chatRoomId, lastMessage);
+        }
+
+        // 6. DTO 변환 (멤버가 볼 수 있는 마지막 메시지만 사용)
         return chatRooms.stream()
                 .map(chatRoom -> dtoConverter.convertToChatRoomListResponseDto(
                         chatRoom,
                         memberId,
-                        lastMessageMap.get(chatRoom.getChatRoomId())
+                        visibleLastMessageMap.get(chatRoom.getChatRoomId())
                 ))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/example/petner/domain/chat/service/ChatRoomQueryService.java
+++ b/src/main/java/com/example/petner/domain/chat/service/ChatRoomQueryService.java
@@ -98,7 +98,7 @@ public class ChatRoomQueryService {
                     // }
                 } else {
                     // joinedAt이 null이면 모든 메시지 볼 수 있음
-                    lastMessage = messageRepository.findTopByChatRoom_ChatRoomIdOrderBySentAtDesc(
+                    lastMessage = messageRepository.findLatestMessageByChatRoomId(
                             chatRoomId).orElse(null);
 
                     // 디버깅용 로그

--- a/src/main/java/com/example/petner/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/example/petner/domain/chat/service/ChatRoomService.java
@@ -3,7 +3,9 @@ package com.example.petner.domain.chat.service;
 import com.example.petner.domain.chat.dto.request.ChatRoomCreateRequestDto;
 import com.example.petner.domain.chat.dto.response.ChatRoomResponseDto;
 import com.example.petner.domain.chat.entity.ChatRoom;
+import com.example.petner.domain.chat.entity.ChatRoomMember;
 import com.example.petner.domain.chat.repository.ChatRoomRepository;
+import com.example.petner.domain.chat.repository.ChatRoomMemberRepository;
 import com.example.petner.domain.dog.entity.Dog;
 import com.example.petner.domain.member.entity.Member;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +17,11 @@ import java.util.Optional;
 /**
  * 채팅방 생성 전용 서비스
  * Single Responsibility Principle을 적용하여 생성 책임만 담당
+ *
+ * 변경사항:
+ * - ChatRoomMember 엔티티를 통한 멤버 관리
+ * - 채팅방 생성 시 ChatRoomMember 레코드도 함께 생성
+ * - 트랜잭션 내에서 양방향 관계 설정
  */
 @Service
 @RequiredArgsConstructor
@@ -22,6 +29,7 @@ import java.util.Optional;
 public class ChatRoomService {
 
     private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
     private final ChatRoomValidator chatRoomValidator;
     private final ChatRoomDuplicateChecker duplicateChecker;
 
@@ -35,7 +43,7 @@ public class ChatRoomService {
      * 1. 입력 검증: member1Id, member2Id로 멤버 존재 여부 확인
      * 2. 강아지 검증: dogId가 있다면 해당 강아지 존재 여부 및 소유자 확인
      * 3. 중복 체크: 동일한 두 멤버 간 기존 채팅방 존재 여부 확인
-     * 4. 채팅방 처리: 기존 채팅방이 있으면 반환, 없으면 새로 생성
+     * 4. 채팅방 처리: 기존 채팅방이 있으면 반환, 없으면 새로 생성 및 멤버 추가
      */
     @Transactional
     public ChatRoomResponseDto createChatRoom(ChatRoomCreateRequestDto requestDto) {
@@ -51,7 +59,9 @@ public class ChatRoomService {
         Dog dog = chatRoomValidator.validateAndGetDog(requestDto.getDogId(), member1, member2);
 
         // 3. 중복 채팅방 체크
-        Optional<ChatRoom> existingChatRoom = duplicateChecker.findExistingChatRoom(dog, member1, member2);
+        Optional<ChatRoom> existingChatRoom = duplicateChecker.findExistingChatRoom(
+                dog, member1.getMemberId(), member2.getMemberId()
+        );
 
         if (existingChatRoom.isPresent()) {
             // 기존 채팅방이 있다면 그것을 반환 (중복 방지)
@@ -60,16 +70,84 @@ public class ChatRoomService {
 
         // 4. 새로운 채팅방 생성
         ChatRoom chatRoom = ChatRoom.builder()
-                .dog(dog)                // 강아지 정보 (선택적)
-                .member1(member1)        // 첫 번째 멤버
-                .member2(member2)        // 두 번째 멤버
+                .dog(dog)  // 강아지 정보 (선택적)
                 .build();
 
         // 5. 데이터베이스에 저장
         ChatRoom savedChatRoom = chatRoomRepository.save(chatRoom);
 
-        // 6. 응답 DTO로 변환하여 반환
+        // 6. 채팅방 멤버 추가
+        createAndAddChatRoomMember(savedChatRoom, member1);
+        createAndAddChatRoomMember(savedChatRoom, member2);
+
+        // 7. 응답 DTO로 변환하여 반환
         return new ChatRoomResponseDto(savedChatRoom);
     }
 
+    /**
+     * 채팅방에 멤버 추가
+     * 양방향 관계를 안전하게 설정하여 데이터 일관성 보장
+     *
+     * @param chatRoom 채팅방
+     * @param member 추가할 멤버
+     */
+    private void createAndAddChatRoomMember(ChatRoom chatRoom, Member member) {
+        ChatRoomMember chatRoomMember = ChatRoomMember.builder()
+                .chatRoom(chatRoom)
+                .member(member)
+                .isActive(true)
+                .build();
+
+        // 양방향 관계 설정
+        chatRoom.addMember(chatRoomMember);
+
+        // 데이터베이스에 저장
+        chatRoomMemberRepository.save(chatRoomMember);
+    }
+
+    /**
+     * 채팅방 나가기
+     * 실제 삭제가 아닌 비활성화 처리
+     *
+     * @param chatRoomId 채팅방 ID
+     * @param memberId 나갈 멤버 ID
+     */
+    @Transactional
+    public void leaveChatRoom(Long chatRoomId, Long memberId) {
+        // 1. 채팅방 조회
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
+
+        // 2. 멤버 비활성화
+        chatRoom.removeMember(memberId);
+    }
+
+    /**
+     * 채팅방 재입장
+     * 비활성화된 멤버를 다시 활성화
+     *
+     * @param chatRoomId 채팅방 ID
+     * @param memberId 재입장할 멤버 ID
+     */
+    @Transactional
+    public void rejoinChatRoom(Long chatRoomId, Long memberId) {
+        // 1. 채팅방 조회
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
+
+        // 2. 멤버 조회
+        Member member = chatRoomValidator.validateAndGetMember(memberId);
+
+        // 3. 기존 ChatRoomMember 조회
+        Optional<ChatRoomMember> existingMember = chatRoomMemberRepository
+                .findByChatRoomAndMember(chatRoom, member);
+
+        if (existingMember.isPresent()) {
+            // 기존 멤버 재활성화
+            existingMember.get().reactivate();
+        } else {
+            // 새로운 멤버 추가
+            createAndAddChatRoomMember(chatRoom, member);
+        }
+    }
 }

--- a/src/main/java/com/example/petner/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/example/petner/domain/chat/service/ChatRoomService.java
@@ -64,8 +64,10 @@ public class ChatRoomService {
         );
 
         if (existingChatRoom.isPresent()) {
-            // 기존 채팅방이 있다면 그것을 반환 (중복 방지)
-            return new ChatRoomResponseDto(existingChatRoom.get());
+            // 기존 채팅방이 있다면 두 멤버를 모두 재활성화하고 반환
+            ChatRoom chatRoom = existingChatRoom.get();
+            reactivateMembersIfNeeded(chatRoom, member1, member2);
+            return new ChatRoomResponseDto(chatRoom);
         }
 
         // 4. 새로운 채팅방 생성
@@ -103,6 +105,40 @@ public class ChatRoomService {
 
         // 데이터베이스에 저장
         chatRoomMemberRepository.save(chatRoomMember);
+    }
+
+    /**
+     * 기존 채팅방의 멤버들을 필요시 재활성화
+     * 두 멤버 중 비활성화된 멤버가 있다면 재활성화
+     *
+     * @param chatRoom 기존 채팅방
+     * @param member1 첫 번째 멤버
+     * @param member2 두 번째 멤버
+     */
+    private void reactivateMembersIfNeeded(ChatRoom chatRoom, Member member1, Member member2) {
+        // 첫 번째 멤버 재활성화
+        reactivateMemberIfNeeded(chatRoom, member1);
+        // 두 번째 멤버 재활성화
+        reactivateMemberIfNeeded(chatRoom, member2);
+    }
+
+    /**
+     * 특정 멤버를 필요시 재활성화
+     *
+     * @param chatRoom 채팅방
+     * @param member 재활성화할 멤버
+     */
+    private void reactivateMemberIfNeeded(ChatRoom chatRoom, Member member) {
+        Optional<ChatRoomMember> existingMember = chatRoomMemberRepository
+                .findByChatRoomAndMember(chatRoom, member);
+
+        if (existingMember.isPresent()) {
+            // 기존 멤버가 있다면 재활성화
+            existingMember.get().reactivate();
+        } else {
+            // 기존 멤버가 없다면 새로 추가
+            createAndAddChatRoomMember(chatRoom, member);
+        }
     }
 
     /**

--- a/src/main/java/com/example/petner/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/example/petner/domain/chat/service/ChatRoomService.java
@@ -8,6 +8,8 @@ import com.example.petner.domain.chat.repository.ChatRoomRepository;
 import com.example.petner.domain.chat.repository.ChatRoomMemberRepository;
 import com.example.petner.domain.dog.entity.Dog;
 import com.example.petner.domain.member.entity.Member;
+import com.example.petner.global.exception.ErrorCode;
+import com.example.petner.global.exception.customException.ChatException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -152,7 +154,7 @@ public class ChatRoomService {
     public void leaveChatRoom(Long chatRoomId, Long memberId) {
         // 1. 채팅방 조회
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
-                .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
+                .orElseThrow(() -> new ChatException(ErrorCode.CHAT_ROOM_NOT_FOUND));
 
         // 2. 멤버 비활성화
         chatRoom.removeMember(memberId);
@@ -169,7 +171,7 @@ public class ChatRoomService {
     public void rejoinChatRoom(Long chatRoomId, Long memberId) {
         // 1. 채팅방 조회
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
-                .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
+                .orElseThrow(() -> new ChatException(ErrorCode.CHAT_ROOM_NOT_FOUND));
 
         // 2. 멤버 조회
         Member member = chatRoomValidator.validateAndGetMember(memberId);

--- a/src/main/java/com/example/petner/domain/chat/service/ChatRoomValidator.java
+++ b/src/main/java/com/example/petner/domain/chat/service/ChatRoomValidator.java
@@ -38,6 +38,17 @@ public class  ChatRoomValidator {
     }
 
     /**
+     * 단일 멤버 존재 여부 검증
+     *
+     * @param memberId 멤버 ID
+     * @return 검증된 멤버
+     */
+    public Member validateAndGetMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new ChatException(ErrorCode.CHAT_MEMBER_NOT_FOUND));
+    }
+
+    /**
      * 강아지 존재 여부 검증 및 소유자 검증
      *
      * @param dogId 강아지 ID (nullable)

--- a/src/main/java/com/example/petner/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/petner/global/exception/ErrorCode.java
@@ -57,7 +57,10 @@ public enum ErrorCode {
     CHAT_DOG_OWNER_MISMATCH("400-CH05", "강아지 소유자가 채팅방 참여자와 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
     CHAT_INVALID_MESSAGE_TYPE("400-CH06", "유효하지 않은 메시지 타입입니다.", HttpStatus.BAD_REQUEST),
     CHAT_INVALID_PAYLOAD("400-CH07", "메시지 페이로드가 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
-    CHAT_ALREADY_ADOPTED("409-CH08", "이미 입양된 강아지입니다", HttpStatus.CONFLICT);
+    CHAT_ALREADY_ADOPTED("409-CH08", "이미 입양된 강아지입니다", HttpStatus.CONFLICT),
+    CHAT_INVALID_REQUEST("400-CH09", "잘못된 채팅 요청입니다.", HttpStatus.BAD_REQUEST),
+    CHAT_DOG_NOT_FOUND("404-CH10", "강아지 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    CHAT_INVALID_SAME_MEMBER("400-CH11", "동일한 사용자끼리는 채팅을 할 수 없습니다.", HttpStatus.BAD_REQUEST);
 
     private final String errorCode;
     private final String message;

--- a/src/main/java/com/example/petner/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/petner/global/exception/ErrorCode.java
@@ -53,10 +53,11 @@ public enum ErrorCode {
     CHAT_ROOM_NOT_FOUND("404-CH01", "채팅방을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     CHAT_MEMBER_NOT_FOUND("404-CH02", "사용자 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     CHAT_UNAUTHORIZED_ACCESS("403-CH03", "채팅방에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
-    CHAT_DOG_OWNER_MISMATCH("400-CH04", "강아지 소유자가 채팅방 참여자와 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
-    CHAT_INVALID_MESSAGE_TYPE("400-CH05", "유효하지 않은 메시지 타입입니다.", HttpStatus.BAD_REQUEST),
-    CHAT_INVALID_PAYLOAD("400-CH06", "메시지 페이로드가 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
-    CHAT_ALREADY_ADOPTED("409-CH07", "이미 입양된 강아지입니다", HttpStatus.CONFLICT);
+    CHAT_ROOM_ACCESS_DENIED("403-CH04", "채팅방에 대한 접근이 거부되었습니다.", HttpStatus.FORBIDDEN),
+    CHAT_DOG_OWNER_MISMATCH("400-CH05", "강아지 소유자가 채팅방 참여자와 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+    CHAT_INVALID_MESSAGE_TYPE("400-CH06", "유효하지 않은 메시지 타입입니다.", HttpStatus.BAD_REQUEST),
+    CHAT_INVALID_PAYLOAD("400-CH07", "메시지 페이로드가 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+    CHAT_ALREADY_ADOPTED("409-CH08", "이미 입양된 강아지입니다", HttpStatus.CONFLICT);
 
     private final String errorCode;
     private final String message;

--- a/src/main/resources/db/migration/V20250922125701__Alter_chat_rooms_table.sql
+++ b/src/main/resources/db/migration/V20250922125701__Alter_chat_rooms_table.sql
@@ -1,0 +1,5 @@
+-- V20250922124901__Alter_chat_rooms_table.sql
+-- 채팅방 참여자 정보를 관리하는 member_id1, member_id2 컬럼을 삭제합니다.
+
+ALTER TABLE chat_rooms DROP COLUMN member_id2;
+ALTER TABLE chat_rooms DROP COLUMN member_id1;

--- a/src/main/resources/db/migration/V20250922125702__Add_index_to_messages_table.sql
+++ b/src/main/resources/db/migration/V20250922125702__Add_index_to_messages_table.sql
@@ -1,0 +1,4 @@
+-- V20250922124902__Add_index_to_messages_table.sql
+-- 특정 채팅방의 메시지를 시간순으로 조회하는 쿼리의 성능을 향상시키기 위해 복합 인덱스를 생성합니다.
+
+CREATE INDEX idx_messages_on_chatroom_and_sent_at ON messages (chat_room_id, sent_at);

--- a/src/main/resources/db/migration/V20250922125703__Create_chat_room_members_table.sql
+++ b/src/main/resources/db/migration/V20250922125703__Create_chat_room_members_table.sql
@@ -1,0 +1,14 @@
+-- V20250922124903__Create_chat_room_members_table.sql
+-- 채팅방과 멤버의 관계 및 사용자별 상태를 관리하기 위한 chat_room_members 테이블을 생성합니다.
+
+CREATE TABLE chat_room_members (
+                                   id BIGSERIAL  PRIMARY KEY,
+                                   chat_room_id BIGINT NOT NULL,
+                                   member_id BIGINT NOT NULL,
+                                   is_active BOOLEAN NOT NULL DEFAULT TRUE,
+                                   exited_at TIMESTAMP NULL,
+
+                                   CONSTRAINT fk_chatroommembers_to_chatrooms FOREIGN KEY (chat_room_id) REFERENCES chat_rooms(chat_room_id),
+                                   CONSTRAINT fk_chatroommembers_to_members FOREIGN KEY (member_id) REFERENCES members(member_id),
+                                   CONSTRAINT uk_chatroom_member UNIQUE (chat_room_id, member_id)
+);

--- a/src/main/resources/db/migration/V20250922125703__Create_chat_room_members_table.sql
+++ b/src/main/resources/db/migration/V20250922125703__Create_chat_room_members_table.sql
@@ -2,7 +2,7 @@
 -- 채팅방과 멤버의 관계 및 사용자별 상태를 관리하기 위한 chat_room_members 테이블을 생성합니다.
 
 CREATE TABLE chat_room_members (
-                                   id BIGSERIAL  PRIMARY KEY,
+                                   chat_room_member_id BIGSERIAL  PRIMARY KEY,
                                    chat_room_id BIGINT NOT NULL,
                                    member_id BIGINT NOT NULL,
                                    is_active BOOLEAN NOT NULL DEFAULT TRUE,

--- a/src/main/resources/db/migration/V20250922161000__Add_joined_at_to_chat_room_members.sql
+++ b/src/main/resources/db/migration/V20250922161000__Add_joined_at_to_chat_room_members.sql
@@ -1,0 +1,16 @@
+-- V20250922161000__Add_joined_at_to_chat_room_members.sql
+-- 채팅방 멤버 테이블에 joined_at 컬럼 추가
+-- 멤버의 입장/재입장 시간을 기록하여 메시지 가시성 제어에 사용
+
+ALTER TABLE chat_room_members
+ADD COLUMN joined_at TIMESTAMP NULL;
+
+-- 기존 레코드들에 대해서는 현재 시간으로 설정 (기존 채팅방은 모든 메시지를 볼 수 있도록)
+UPDATE chat_room_members
+SET joined_at = CURRENT_TIMESTAMP
+WHERE joined_at IS NULL;
+
+-- 새로 생성되는 레코드는 엔티티에서 자동으로 설정됨
+
+-- 인덱스 추가 (메시지 가시성 필터링 성능 향상)
+CREATE INDEX idx_chat_room_members_joined_at ON chat_room_members(joined_at);

--- a/src/main/resources/static/chat/chat-test.html
+++ b/src/main/resources/static/chat/chat-test.html
@@ -32,6 +32,9 @@
         .user-actions { display: flex; gap: 5px; }
         .create-room-form { background-color: #f8f9fa; padding: 15px; border-radius: 4px; margin-bottom: 20px; }
         #messages { height: 300px; border: 1px solid #ddd; border-radius: 4px; padding: 10px; margin-bottom: 10px; overflow-y: auto; display: flex; flex-direction: column; }
+        #load-more-btn { background-color: #6c757d; color: white; padding: 8px 12px; border: none; border-radius: 4px; cursor: pointer; margin-bottom: 10px; font-size: 14px; }
+        #load-more-btn:hover { background-color: #5a6268; }
+        #load-more-btn:disabled { background-color: #ccc; cursor: not-allowed; }
         .message { padding: 8px 12px; border-radius: 18px; margin-bottom: 8px; max-width: 70%; word-wrap: break-word; }
         .sent { background-color: #5c67f2; color: white; align-self: flex-end; }
         .received { background-color: #e5e5ea; color: black; align-self: flex-start; }
@@ -86,6 +89,7 @@
                 <button onclick="goBackToMain()" class="secondary">뒤로가기</button>
             </div>
         </div>
+        <button id="load-more-btn" onclick="loadMoreMessages()" style="display: none;">이전 메시지 더 보기</button>
         <div id="messages"></div>
         <form id="chat-form" onsubmit="sendMessage(event)">
             <input type="text" id="message-input" placeholder="메시지를 입력하세요..." autocomplete="off">
@@ -101,6 +105,9 @@
     let stompClient = null;
     let allUsers = [];
     let refreshTimeout = null; // 새로고침 디바운싱용
+    let currentPage = 0; // 현재 페이지
+    let pageSize = 50; // 페이지 크기
+    let hasMoreMessages = true; // 더 많은 메시지가 있는지 여부
 
     function showArea(areaId) {
         document.querySelectorAll('.area').forEach(area => area.style.display = 'none');
@@ -298,6 +305,9 @@
 
     async function enterChatRoom(chatRoomId, otherNickname) {
         currentChatRoomId = chatRoomId;
+        currentPage = 0; // 페이지 초기화
+        hasMoreMessages = true; // 더 많은 메시지 있음으로 초기화
+
         document.getElementById('chat-with-title').innerText = `${otherNickname}님과의 채팅`;
         showArea('chat-area');
 
@@ -305,16 +315,102 @@
         messagesDiv.innerHTML = '<div class="alert alert-info">메시지를 불러오는 중...</div>';
 
         try {
-            // 멤버별 가시 메시지 전체 조회 API 사용 (페이징 없음)
-            const response = await fetch(`${API_BASE_URL}/api/v1/chat/rooms/${chatRoomId}/messages/visible/all?memberId=${currentMemberId}`);
-            const messages = await response.json();
-            messagesDiv.innerHTML = '';
-            messages.forEach(displayMessage);
+            // 멤버별 가시 메시지 페이징 조회 API 사용
+            await loadMessages(true); // 첫 번째 로드
         } catch (error) {
             messagesDiv.innerHTML = '<div class="alert alert-error">대화 내역을 불러오는데 실패했습니다.</div>';
         }
 
         connectAndSubscribe();
+    }
+
+    async function loadMessages(isInitialLoad = false) {
+        const messagesDiv = document.getElementById('messages');
+        const loadMoreBtn = document.getElementById('load-more-btn');
+
+        try {
+            const response = await fetch(
+                `${API_BASE_URL}/api/v1/chat/rooms/${currentChatRoomId}/messages/visible?memberId=${currentMemberId}&page=${currentPage}&size=${pageSize}`
+            );
+
+            if (!response.ok) {
+                throw new Error('메시지를 불러오는데 실패했습니다.');
+            }
+
+            const messages = await response.json();
+
+            if (isInitialLoad) {
+                messagesDiv.innerHTML = '';
+            }
+
+            // 메시지가 없으면 더 이상 불러올 메시지가 없음
+            if (messages.length === 0) {
+                hasMoreMessages = false;
+                loadMoreBtn.style.display = 'none';
+                if (isInitialLoad) {
+                    messagesDiv.innerHTML = '<div class="alert alert-info">메시지가 없습니다.</div>';
+                }
+                return;
+            }
+
+            // 메시지가 페이지 크기보다 적으면 더 이상 불러올 메시지가 없음
+            if (messages.length < pageSize) {
+                hasMoreMessages = false;
+                loadMoreBtn.style.display = 'none';
+            } else {
+                loadMoreBtn.style.display = hasMoreMessages ? 'block' : 'none';
+            }
+
+            if (isInitialLoad) {
+                // 첫 로드시에는 그냥 추가
+                messages.forEach(displayMessage);
+                // 스크롤을 맨 아래로
+                messagesDiv.scrollTop = messagesDiv.scrollHeight;
+            } else {
+                // 이전 메시지 로드시에는 맨 위에 추가
+                const currentScrollHeight = messagesDiv.scrollHeight;
+                messages.reverse().forEach(message => {
+                    const messageElement = createMessageElement(message);
+                    messagesDiv.insertBefore(messageElement, messagesDiv.firstChild);
+                });
+                // 스크롤 위치 유지
+                messagesDiv.scrollTop = messagesDiv.scrollHeight - currentScrollHeight;
+            }
+
+        } catch (error) {
+            console.error('메시지 로드 오류:', error);
+            if (isInitialLoad) {
+                messagesDiv.innerHTML = '<div class="alert alert-error">대화 내역을 불러오는데 실패했습니다.</div>';
+            }
+        }
+    }
+
+    async function loadMoreMessages() {
+        if (!hasMoreMessages) return;
+
+        const loadMoreBtn = document.getElementById('load-more-btn');
+        loadMoreBtn.disabled = true;
+        loadMoreBtn.textContent = '로딩 중...';
+
+        currentPage++;
+        await loadMessages(false);
+
+        loadMoreBtn.disabled = false;
+        loadMoreBtn.textContent = '이전 메시지 더 보기';
+    }
+
+    function createMessageElement(message) {
+        const messageElement = document.createElement('div');
+        messageElement.classList.add('message');
+        messageElement.innerText = message.content;
+
+        if (message.senderId === currentMemberId) {
+            messageElement.classList.add('sent');
+        } else {
+            messageElement.classList.add('received');
+        }
+
+        return messageElement;
     }
 
     async function leaveChatRoom() {

--- a/src/main/resources/static/chat/chat-test.html
+++ b/src/main/resources/static/chat/chat-test.html
@@ -1,3 +1,4 @@
+<!-- http://localhost:8080/chat/chat-test.html 로 접속-->
 <!DOCTYPE html>
 <html lang="ko">
 <head>

--- a/src/main/resources/static/chat/chat-test.html
+++ b/src/main/resources/static/chat/chat-test.html
@@ -3,54 +3,94 @@
 <html lang="ko">
 <head>
     <meta charset="UTF-8">
-    <title>채팅 기능 테스트 (ERD 기반)</title>
+    <title>채팅 기능 완전 테스트</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/sockjs-client/1.5.1/sockjs.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.3/stomp.min.js"></script>
     <style>
-        /* CSS는 변경 없음 */
         body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; margin: 20px; background-color: #f4f4f9; }
-        .container { max-width: 600px; margin: auto; background: white; padding: 20px; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); }
+        .container { max-width: 800px; margin: auto; background: white; padding: 20px; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); }
         .area { display: none; }
         #login-area { display: block; }
-        h2, h3 { color: #333; }
+        h2, h3, h4 { color: #333; }
         input[type="text"], input[type="number"] { width: calc(100% - 22px); padding: 10px; margin-bottom: 10px; border: 1px solid #ddd; border-radius: 4px; }
-        button { background-color: #5c67f2; color: white; padding: 10px 15px; border: none; border-radius: 4px; cursor: pointer; font-size: 16px; }
+        button { background-color: #5c67f2; color: white; padding: 10px 15px; border: none; border-radius: 4px; cursor: pointer; font-size: 16px; margin: 5px; }
         button:hover { background-color: #4a54c4; }
-        #room-list div { padding: 10px; border: 1px solid #eee; border-radius: 4px; margin-top: 5px; cursor: pointer; }
-        #room-list div:hover { background-color: #f0f0f0; }
+        button.danger { background-color: #ff4757; }
+        button.danger:hover { background-color: #ff3742; }
+        button.secondary { background-color: #6c757d; }
+        button.secondary:hover { background-color: #5a6268; }
+        .flex-container { display: flex; gap: 20px; }
+        .left-panel { flex: 1; }
+        .right-panel { flex: 1; }
+        .room-item, .user-item { padding: 10px; border: 1px solid #eee; border-radius: 4px; margin-bottom: 10px; cursor: pointer; }
+        .room-item:hover, .user-item:hover { background-color: #f0f0f0; }
         .room-title { font-weight: bold; margin-bottom: 4px; }
         .room-last-message { font-size: 12px; color: #666; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+        .member-count { font-size: 12px; color: #007bff; font-weight: bold; }
+        .user-item { display: flex; justify-content: space-between; align-items: center; }
+        .user-info { flex-grow: 1; }
+        .user-actions { display: flex; gap: 5px; }
+        .create-room-form { background-color: #f8f9fa; padding: 15px; border-radius: 4px; margin-bottom: 20px; }
         #messages { height: 300px; border: 1px solid #ddd; border-radius: 4px; padding: 10px; margin-bottom: 10px; overflow-y: auto; display: flex; flex-direction: column; }
         .message { padding: 8px 12px; border-radius: 18px; margin-bottom: 8px; max-width: 70%; word-wrap: break-word; }
         .sent { background-color: #5c67f2; color: white; align-self: flex-end; }
         .received { background-color: #e5e5ea; color: black; align-self: flex-start; }
         #chat-form { display: flex; }
         #chat-form input { flex-grow: 1; margin-right: 10px; margin-bottom: 0; }
+        .alert { padding: 10px; margin: 10px 0; border-radius: 4px; }
+        .alert-success { background-color: #d4edda; color: #155724; border: 1px solid #c3e6cb; }
+        .alert-error { background-color: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; }
+        .alert-info { background-color: #d1ecf1; color: #0c5460; border: 1px solid #bee5eb; }
     </style>
 </head>
 <body>
 
 <div class="container">
+    <!-- 로그인 화면 -->
     <div id="login-area" class="area">
-        <h2>로그인</h2>
+        <h2>채팅 시스템 로그인</h2>
         <input type="number" id="memberId" placeholder="로그인할 Member ID를 입력하세요 (예: 1)">
         <button onclick="login()">로그인</button>
     </div>
 
-    <div id="room-list-area" class="area">
-        <h2 id="room-list-title"></h2>
-        <div id="room-list"></div>
-        <button onclick="logout()">로그아웃</button>
+    <!-- 메인 채팅 화면 -->
+    <div id="main-area" class="area">
+        <div class="flex-container">
+            <!-- 왼쪽 패널: 채팅방 목록 -->
+            <div class="left-panel">
+                <h3 id="room-list-title">내 채팅방 목록</h3>
+                <div id="room-list">채팅방을 불러오는 중...</div>
+                <button onclick="logout()" class="secondary">로그아웃</button>
+            </div>
+
+            <!-- 오른쪽 패널: 사용자 목록 및 채팅방 생성 -->
+            <div class="right-panel">
+                <h3>새 채팅방 만들기</h3>
+                <div class="create-room-form">
+                    <h4>상대방 Member ID:</h4>
+                    <input type="number" id="otherMemberId" placeholder="채팅할 상대방의 Member ID를 입력하세요">
+                    <h4>강아지 ID (선택사항):</h4>
+                    <input type="number" id="dogId" placeholder="강아지 ID (비워두면 일반 채팅)">
+                    <button onclick="createChatRoomWithIds()">채팅방 생성</button>
+                </div>
+            </div>
+        </div>
     </div>
 
+    <!-- 채팅 화면 -->
     <div id="chat-area" class="area">
-        <h3 id="chat-with-title"></h3>
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h3 id="chat-with-title">채팅</h3>
+            <div>
+                <button onclick="leaveChatRoom()" class="danger">채팅방 나가기</button>
+                <button onclick="goBackToMain()" class="secondary">뒤로가기</button>
+            </div>
+        </div>
         <div id="messages"></div>
         <form id="chat-form" onsubmit="sendMessage(event)">
             <input type="text" id="message-input" placeholder="메시지를 입력하세요..." autocomplete="off">
             <button type="submit">전송</button>
         </form>
-        <button onclick="goBackToRoomList()">뒤로가기</button>
     </div>
 </div>
 
@@ -59,96 +99,266 @@
     let currentMemberId = null;
     let currentChatRoomId = null;
     let stompClient = null;
+    let allUsers = [];
+    let refreshTimeout = null; // 새로고침 디바운싱용
 
     function showArea(areaId) {
         document.querySelectorAll('.area').forEach(area => area.style.display = 'none');
         document.getElementById(areaId).style.display = 'block';
     }
 
-    function login() {
+    function showAlert(message, type = 'info') {
+        const alertDiv = document.createElement('div');
+        alertDiv.className = `alert alert-${type}`;
+        alertDiv.textContent = message;
+        document.querySelector('.container').insertBefore(alertDiv, document.querySelector('.container').firstChild);
+        setTimeout(() => alertDiv.remove(), 3000);
+    }
+
+    // 채팅방 목록 새로고침을 디바운싱하는 함수
+    function debouncedRefreshChatRooms() {
+        if (refreshTimeout) {
+            clearTimeout(refreshTimeout);
+        }
+        refreshTimeout = setTimeout(() => {
+            // 메인 화면에 있을 때만 새로고침
+            const mainArea = document.getElementById('main-area');
+            if (mainArea && mainArea.style.display !== 'none') {
+                loadChatRooms();
+            }
+        }, 300); // 300ms 지연
+    }
+
+    // 즉시 새로고침 함수 (디바운싱 없음)
+    function immediateRefreshChatRooms() {
+        const mainArea = document.getElementById('main-area');
+        if (mainArea && mainArea.style.display !== 'none') {
+            loadChatRooms();
+        }
+    }
+
+    async function login() {
         const memberId = document.getElementById('memberId').value;
-        if (!memberId) { alert("Member ID를 입력하세요."); return; }
+        if (!memberId) {
+            showAlert("Member ID를 입력하세요.", 'error');
+            return;
+        }
+
         currentMemberId = parseInt(memberId, 10);
-        document.getElementById('room-list-title').innerText = `채팅 목록 (로그인: ${currentMemberId}번 유저)`;
-        showArea('room-list-area');
-        loadChatRooms();
+        document.getElementById('room-list-title').innerText = `내 채팅방 목록 (ID: ${currentMemberId})`;
+
+        showArea('main-area');
+        await loadChatRooms();
+
+        showAlert(`${currentMemberId}번 사용자로 로그인했습니다.`, 'success');
     }
 
     function logout() {
         if (stompClient) { stompClient.disconnect(); }
-        currentMemberId = null; currentChatRoomId = null; stompClient = null;
+        currentMemberId = null;
+        currentChatRoomId = null;
+        stompClient = null;
         document.getElementById('memberId').value = '';
+        document.getElementById('otherMemberId').value = '';
+        document.getElementById('dogId').value = '';
         showArea('login-area');
+        showAlert('로그아웃했습니다.', 'info');
+    }
+
+    async function createChatRoomWithIds() {
+        const otherMemberId = document.getElementById('otherMemberId').value;
+        const dogId = document.getElementById('dogId').value;
+
+        if (!otherMemberId) {
+            showAlert("상대방 Member ID를 입력하세요.", 'error');
+            return;
+        }
+
+        if (parseInt(otherMemberId) === currentMemberId) {
+            showAlert("자기 자신과는 채팅방을 만들 수 없습니다.", 'error');
+            return;
+        }
+
+        const requestData = {
+            member1Id: currentMemberId,
+            member2Id: parseInt(otherMemberId),
+            dogId: dogId ? parseInt(dogId) : null
+        };
+
+        try {
+            const response = await fetch(`${API_BASE_URL}/api/v1/chat/rooms`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(requestData)
+            });
+
+            if (!response.ok) {
+                throw new Error('채팅방 생성에 실패했습니다.');
+            }
+
+            const result = await response.json();
+            const dogText = dogId ? ` (강아지 ID: ${dogId})` : ' (일반 채팅)';
+            showAlert(`Member ID ${otherMemberId}님과의 채팅방이 생성되었습니다${dogText}`, 'success');
+
+            // 입력 필드 초기화
+            document.getElementById('otherMemberId').value = '';
+            document.getElementById('dogId').value = '';
+
+            // 채팅방 목록 즉시 새로고침
+            immediateRefreshChatRooms();
+
+            // 생성된 채팅방으로 바로 이동 (선택사항)
+            if (result && result.chatRoomId) {
+                setTimeout(() => {
+                    enterChatRoom(result.chatRoomId, `Member ${otherMemberId}`);
+                }, 500);
+            }
+
+        } catch (error) {
+            console.error('채팅방 생성 오류:', error);
+            showAlert('채팅방 생성에 실패했습니다. 이미 존재하는 채팅방일 수 있습니다.', 'error');
+        }
     }
 
     async function loadChatRooms() {
         const roomListDiv = document.getElementById('room-list');
         roomListDiv.innerHTML = '채팅방을 불러오는 중...';
+
         try {
             const response = await fetch(`${API_BASE_URL}/api/v1/chat/rooms/members/${currentMemberId}`);
             if (!response.ok) throw new Error('채팅방 목록을 불러오는데 실패했습니다.');
+
             const rooms = await response.json();
             roomListDiv.innerHTML = '';
-            if (rooms.length === 0) { roomListDiv.innerHTML = '참여중인 채팅방이 없습니다.'; return; }
-            rooms.forEach(room => {
+
+            if (rooms.length === 0) {
+                roomListDiv.innerHTML = '<div class="alert alert-info">참여중인 채팅방이 없습니다. 오른쪽에서 새 채팅방을 만들어보세요!</div>';
+                return;
+            }
+
+            // 각 채팅방의 활성 멤버 수를 가져와서 표시
+            for (const room of rooms) {
                 const roomDiv = document.createElement('div');
+                roomDiv.className = 'room-item';
 
                 // 채팅방 제목 생성
                 const titleDiv = document.createElement('div');
                 titleDiv.className = 'room-title';
                 let roomTitle = `${room.otherMemberInfo.nickname}님과의 대화`;
                 if (room.dogInfo && room.dogInfo.name) {
-                    roomTitle += ` (🐶 강아지: ${room.dogInfo.name})`;
+                    roomTitle += ` (🐶 ${room.dogInfo.name})`;
                 } else {
                     roomTitle += ` (일반 채팅)`;
                 }
                 titleDiv.innerText = roomTitle;
 
-                // 최근 메시지 생성
+                // 최근 메시지
                 const lastMessageDiv = document.createElement('div');
                 lastMessageDiv.className = 'room-last-message';
-                if (room.lastMessageContent) {
-                    lastMessageDiv.innerText = room.lastMessageContent;
-                } else {
-                    lastMessageDiv.innerText = '아직 메시지가 없습니다';
+                lastMessageDiv.innerText = room.lastMessageContent || '아직 메시지가 없습니다';
+
+                // 활성 멤버 수 가져오기 및 표시
+                try {
+                    const countResponse = await fetch(`${API_BASE_URL}/api/v1/chat/rooms/${room.chatRoomId}/members/count`);
+                    if (countResponse.ok) {
+                        const countData = await countResponse.json();
+                        const memberCountDiv = document.createElement('div');
+                        memberCountDiv.className = 'member-count';
+                        memberCountDiv.innerText = `활성 멤버: ${countData.activeMemberCount}명`;
+                        roomDiv.appendChild(titleDiv);
+                        roomDiv.appendChild(lastMessageDiv);
+                        roomDiv.appendChild(memberCountDiv);
+                    } else {
+                        roomDiv.appendChild(titleDiv);
+                        roomDiv.appendChild(lastMessageDiv);
+                    }
+                } catch (error) {
+                    roomDiv.appendChild(titleDiv);
+                    roomDiv.appendChild(lastMessageDiv);
                 }
 
-                roomDiv.appendChild(titleDiv);
-                roomDiv.appendChild(lastMessageDiv);
                 roomDiv.onclick = () => enterChatRoom(room.chatRoomId, room.otherMemberInfo.nickname);
                 roomListDiv.appendChild(roomDiv);
-            });
-        } catch (error) { roomListDiv.innerHTML = error.message; }
+            }
+        } catch (error) {
+            roomListDiv.innerHTML = `<div class="alert alert-error">${error.message}</div>`;
+        }
     }
 
-    function goBackToRoomList() {
-        if(stompClient) { stompClient.disconnect(); stompClient = null; }
-        showArea('room-list-area');
-        loadChatRooms();
+    function goBackToMain() {
+        if(stompClient) {
+            stompClient.disconnect();
+            stompClient = null;
+        }
+        showArea('main-area');
+
+        // 즉시 새로고침
+        immediateRefreshChatRooms();
     }
 
     async function enterChatRoom(chatRoomId, otherNickname) {
         currentChatRoomId = chatRoomId;
         document.getElementById('chat-with-title').innerText = `${otherNickname}님과의 채팅`;
         showArea('chat-area');
+
         const messagesDiv = document.getElementById('messages');
-        messagesDiv.innerHTML = '';
+        messagesDiv.innerHTML = '<div class="alert alert-info">메시지를 불러오는 중...</div>';
+
         try {
             const response = await fetch(`${API_BASE_URL}/api/v1/chat/rooms/${chatRoomId}/messages/all`);
             const messages = await response.json();
-            messages.forEach(displayMessage); // ERD에 맞춘 응답 필드를 사용
-        } catch (error) { displayMessage({ content: "대화 내역을 불러오는데 실패했습니다." }); }
+            messagesDiv.innerHTML = '';
+            messages.forEach(displayMessage);
+        } catch (error) {
+            messagesDiv.innerHTML = '<div class="alert alert-error">대화 내역을 불러오는데 실패했습니다.</div>';
+        }
+
         connectAndSubscribe();
+    }
+
+    async function leaveChatRoom() {
+        if (!currentChatRoomId) return;
+
+        if (!confirm('정말로 이 채팅방을 나가시겠습니까?')) return;
+
+        try {
+            const response = await fetch(`${API_BASE_URL}/api/v1/chat/rooms/${currentChatRoomId}/members/${currentMemberId}`, {
+                method: 'DELETE'
+            });
+
+            if (response.ok) {
+                const result = await response.json();
+                showAlert(result.message || '채팅방을 나갔습니다.', 'success');
+                goBackToMain();
+            } else {
+                throw new Error('채팅방 나가기에 실패했습니다.');
+            }
+        } catch (error) {
+            console.error('채팅방 나가기 오류:', error);
+            showAlert('채팅방 나가기에 실패했습니다.', 'error');
+        }
     }
 
     function connectAndSubscribe() {
         if (stompClient) { stompClient.disconnect(); }
+
         const socket = new SockJS(`${API_BASE_URL}/ws-stomp`);
         stompClient = Stomp.over(socket);
+
         stompClient.connect({}, (frame) => {
+            console.log('WebSocket 연결됨:', frame);
+
+            // 현재 채팅방 구독
             stompClient.subscribe(`/topic/chat/${currentChatRoomId}`, (message) => {
-                displayMessage(JSON.parse(message.body));
+                const messageData = JSON.parse(message.body);
+                displayMessage(messageData);
+
+                // 메시지 수신 시 채팅방 목록 새로고침 (최근 메시지로 인한 순서 변경)
+                debouncedRefreshChatRooms();
             });
+        }, (error) => {
+            console.error('WebSocket 연결 실패:', error);
+            showAlert('실시간 채팅 연결에 실패했습니다.', 'error');
         });
     }
 
@@ -156,10 +366,19 @@
         event.preventDefault();
         const messageInput = document.getElementById('message-input');
         const content = messageInput.value.trim();
-        if (content && stompClient) {
-            const chatMessage = { senderId: currentMemberId, content: content };
+
+        if (content && stompClient && stompClient.connected) {
+            const chatMessage = {
+                senderId: currentMemberId,
+                content: content
+            };
             stompClient.send(`/app/chat/${currentChatRoomId}`, {}, JSON.stringify(chatMessage));
             messageInput.value = '';
+
+            // 메시지 전송 후 채팅방 목록 새로고침 (최근 메시지로 인한 순서 변경)
+            debouncedRefreshChatRooms();
+        } else if (!stompClient || !stompClient.connected) {
+            showAlert('채팅 연결이 끊어졌습니다. 다시 접속해주세요.', 'error');
         }
     }
 
@@ -167,17 +386,43 @@
         const messagesDiv = document.getElementById('messages');
         const messageElement = document.createElement('div');
         messageElement.classList.add('message');
-        // `Messages` 테이블의 `content` 컬럼을 사용
         messageElement.innerText = message.content;
-        // `Messages` 테이블의 `senderId` 컬럼을 사용
+
         if (message.senderId === currentMemberId) {
             messageElement.classList.add('sent');
         } else {
             messageElement.classList.add('received');
         }
+
         messagesDiv.appendChild(messageElement);
         messagesDiv.scrollTop = messagesDiv.scrollHeight;
     }
+
+    // 페이지 로드 시 실행
+    window.addEventListener('beforeunload', () => {
+        if (stompClient) {
+            stompClient.disconnect();
+        }
+    });
+
+    // 페이지 가시성 변경 시 새로고침 (탭 전환 시)
+    document.addEventListener('visibilitychange', () => {
+        if (!document.hidden && currentMemberId) {
+            // 페이지가 다시 보이게 되었을 때 새로고침
+            setTimeout(() => {
+                debouncedRefreshChatRooms();
+            }, 100);
+        }
+    });
+
+    // 윈도우 포커스 시에도 새로고침
+    window.addEventListener('focus', () => {
+        if (currentMemberId) {
+            setTimeout(() => {
+                debouncedRefreshChatRooms();
+            }, 100);
+        }
+    });
 </script>
 </body>
 </html>

--- a/src/main/resources/static/chat/chat-test.html
+++ b/src/main/resources/static/chat/chat-test.html
@@ -305,7 +305,8 @@
         messagesDiv.innerHTML = '<div class="alert alert-info">메시지를 불러오는 중...</div>';
 
         try {
-            const response = await fetch(`${API_BASE_URL}/api/v1/chat/rooms/${chatRoomId}/messages/all`);
+            // 멤버별 가시 메시지 전체 조회 API 사용 (페이징 없음)
+            const response = await fetch(`${API_BASE_URL}/api/v1/chat/rooms/${chatRoomId}/messages/visible/all?memberId=${currentMemberId}`);
             const messages = await response.json();
             messagesDiv.innerHTML = '';
             messages.forEach(displayMessage);

--- a/src/main/resources/static/chat/chat-test.html
+++ b/src/main/resources/static/chat/chat-test.html
@@ -345,6 +345,7 @@
 
         const socket = new SockJS(`${API_BASE_URL}/ws-stomp`);
         stompClient = Stomp.over(socket);
+        stompClient.debug = null; // STOMP 디버깅 메시지 비활성화
 
         stompClient.connect({}, (frame) => {
             console.log('WebSocket 연결됨:', frame);


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->

# 연관 이슈 및 Close 할 이슈 작성
사용자 경험 향상을 위해 채팅방 '나가기(숨김)' 기능을 구현합니다.
본 기능은 사용자가 채팅방을 나갈 경우, 해당 사용자의 목록에서만 채팅방을 숨기는 논리적 삭제(Soft Delete) 방식입니다. 상대방이 새로운 메시지를 보내면 다시 채팅방이 목록에 나타나며, 이때는 사용자가 나간 시점 이후의 메시지만 조회되도록 하여 대화의 연속성을 자연스럽게 이어갑니다.

이를 위해 기존 `chat_rooms` 테이블의 구조를 변경하고, 사용자별 채팅방 상태를 관리하는 `chat_room_members` 테이블을 새롭게 도입합니다. 모든 데이터베이스 스키마 변경은 Flyway를 통해 체계적으로 관리합니다.

Closes #18 

# Pull Request 체크리스트
**✅ DB 스키마 변경 (Flyway)**

- [x] 🔥 `chat_rooms` 테이블 구조 변경 (`ALTER`)
  - `member_id1`, `member_id2` 컬럼 제거
- [x] 🔥 `chat_room_members` 테이블 신규 생성 (`CREATE`)
  - `is_active` (목록 노출 여부), `exited_at` (나간 시간) 컬럼 포함
  - `chat_room_id`, `member_id` 복합 유니크 키 설정
- [x] 🔥 Flyway 마이그레이션 스크립트 3개 작성
  - `V...__Alter_chat_rooms_table.sql`
  - `V...__Add_index_to_messages_table.sql`
  - `V...__Create_chat_room_members_table.sql`

**✅ 엔티티 수정**

- [x] 🔥 `ChatRoom` 엔티티 수정
  - `member1`, `member2` 필드 제거
  - `List<ChatRoomMember>` 연관관계 매핑 추가 (`@OneToMany`)
- [x] 🔥 `ChatRoomMember` 엔티티 신규 생성
  - `ChatRoom`, `Member`와 `@ManyToOne` 연관관계 설정
  - `isActive`, `exitedAt` 필드 추가

**✅ API Request/Response DTO**

- [x] 🔥 채팅방 나가기: `ChatRoomExitRequestDto`
  - `memberId` 필드 포함 (인증 구현 전 임시)

**✅ API 엔드포인트**

- [x] 🔥 채팅방 나가기(숨김): `DELETE /api/v1/chat/rooms/{roomId}`
- [x] 🔥 메시지 내역 조회 로직 수정: `GET /api/v1/chat/rooms/{chatRoomId}/messages`
  - `exited_at` 시간을 기준으로 이전 메시지를 필터링하는 로직으로 변경

**✅ 비즈니스 로직**

- [x] 🔥 채팅방 나가기(`exitChatRoom`) 로직
  - `ChatRoomMember`의 `is_active`를 `false`로, `exited_at`을 현재 시간으로 업데이트
- [x] 🔥 메시지 수신 시 채팅방 재활성화(`saveMessage`) 로직
  - 메시지 저장 시, 비활성 상태(`is_active=false`)인 참여자를 찾아 `true`로 변경
- [x] 🔥 메시지 필터링(`getMessages`) 로직
  - `MessageRepository`에 `exited_at`을 조건으로 하는 JPQL 커스텀 쿼리 추가

**✅ 기술적 구현**

- [x] 🔥 Flyway를 이용한 데이터베이스 스키마 버전 관리 및 마이그레이션
- [x] 🔥 Swagger 문서 업데이트 (신규 API 반영)
- [x] 🔥 관련 기능 예외 처리 및 로깅 보강

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat: 깃허브 로그인 버튼 컴포넌트 구현 (#10)
    - 나쁜 예시) feat: 로그인 구현