### PR TITLE
[Feature] 이벤트 기반 검색 모듈 및 OpenSearch 연동 (Post) - feature/ddd-21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,10 @@ dependencies {
     // Swagger/OpenAPI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
+    // OpenSearch (using Elasticsearch starter for compatibility)
+    implementation 'org.opensearch.client:opensearch-java:2.11.0'
+    implementation 'org.opensearch.client:opensearch-rest-client:2.11.0'
+
     // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
     implementation 'org.opensearch.client:opensearch-java:2.11.0'
     implementation 'org.opensearch.client:opensearch-rest-client:2.11.0'
 
+    // Jackson JSR310 for LocalDateTime serialization
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
     // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/example/petner/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/petner/domain/post/controller/PostController.java
@@ -5,6 +5,8 @@ import com.example.petner.domain.post.dto.request.PostUpdateRequest;
 import com.example.petner.domain.post.dto.response.PostResponse;
 import com.example.petner.domain.post.dto.response.PostSummaryResponse;
 import com.example.petner.domain.post.service.PostService;
+import com.example.petner.search.document.PostDocument;
+import com.example.petner.search.service.PostSearchService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/posts")
@@ -28,6 +31,7 @@ import java.net.URI;
 public class PostController {
 
     private final PostService postService;
+    private final PostSearchService postSearchService;
 
     @PostMapping
     @Operation(summary = "게시물 생성", description = "새로운 게시물을 생성합니다.")
@@ -87,5 +91,18 @@ public class PostController {
         // TODO: 추후 인증 기능이 구현되면, 게시물 작성자와 현재 로그인한 사용자가 동일한지 확인해야 합니다.
         postService.deletePost(postId);
         return ResponseEntity.ok("게시물이 성공적으로 삭제되었습니다.");
+    }
+
+    @GetMapping("/search")
+    @Operation(summary = "게시물 검색", description = "키워드를 통해 게시물을 검색하고 정렬할 수 있습니다.")
+    @ApiResponse(responseCode = "200", description = "게시물 검색 성공")
+    public ResponseEntity<List<PostDocument>> searchPosts(
+            @Parameter(description = "검색 키워드", example = "강아지") @RequestParam(required = false) String q,
+            @Parameter(description = "정렬 방식 (latest, oldest, viewCount)", example = "latest") @RequestParam(defaultValue = "latest") String sort,
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기", example = "10") @RequestParam(defaultValue = "10") int size) {
+
+        List<PostDocument> response = postSearchService.searchPosts(q, sort, page, size);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/petner/domain/post/service/PostService.java
+++ b/src/main/java/com/example/petner/domain/post/service/PostService.java
@@ -11,7 +11,9 @@ import com.example.petner.domain.post.entity.Post;
 import com.example.petner.global.exception.ErrorCode;
 import com.example.petner.global.exception.customException.MemberException;
 import com.example.petner.global.exception.customException.PostException;
+import com.example.petner.search.event.PostEvent;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -24,6 +26,7 @@ public class PostService {
 
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public PostResponse createPost(Long authorId, PostCreateRequest request) {
@@ -38,6 +41,10 @@ public class PostService {
                 .build();
 
         Post savedPost = postRepository.save(post);
+
+        // OpenSearch 동기화를 위한 이벤트 발행
+        eventPublisher.publishEvent(PostEvent.created(savedPost.getPostId()));
+
         return new PostResponse(savedPost);
     }
 
@@ -46,6 +53,10 @@ public class PostService {
         Post post = postRepository.findByIdWithAuthor(postId)
                 .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
         post.increaseViewCount();
+
+        // OpenSearch 동기화를 위한 이벤트 발행 (조회수 업데이트)
+        eventPublisher.publishEvent(PostEvent.updated(postId));
+
         return new PostResponse(post);
     }
 
@@ -63,6 +74,9 @@ public class PostService {
 
         post.update(request.getTitle(), request.getContent(), request.getThumbImageUrl());
 
+        // OpenSearch 동기화를 위한 이벤트 발행
+        eventPublisher.publishEvent(PostEvent.updated(postId));
+
         return new PostResponse(post);
     }
 
@@ -74,5 +88,8 @@ public class PostService {
         // TODO: Implement author check for delete permission
 
         postRepository.delete(post);
+
+        // OpenSearch 동기화를 위한 이벤트 발행
+        eventPublisher.publishEvent(PostEvent.deleted(postId));
     }
 }

--- a/src/main/java/com/example/petner/global/config/AsyncConfig.java
+++ b/src/main/java/com/example/petner/global/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package com.example.petner.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "searchSyncExecutor")
+    public Executor searchSyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("SearchSync-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/example/petner/global/config/IndexInitializer.java
+++ b/src/main/java/com/example/petner/global/config/IndexInitializer.java
@@ -1,0 +1,170 @@
+package com.example.petner.global.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.opensearch.client.RestClient;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.IOException;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class IndexInitializer {
+
+    private final RestClient restClient;
+
+    @Bean
+    public ApplicationRunner initializeIndices() {
+        return args -> {
+            try {
+                createPostsIndex();
+                createDogsIndex();
+                log.info("OpenSearch indices initialized successfully");
+            } catch (Exception e) {
+                log.error("Failed to initialize OpenSearch indices", e);
+            }
+        };
+    }
+
+    private void createPostsIndex() throws IOException {
+        String indexName = "posts";
+
+        if (!indexExists(indexName)) {
+            String mapping = """
+                {
+                  "settings": {
+                    "analysis": {
+                      "analyzer": {
+                        "nori_analyzer": {
+                          "type": "custom",
+                          "tokenizer": "nori_tokenizer",
+                          "filter": ["lowercase", "nori_part_of_speech"]
+                        }
+                      },
+                      "tokenizer": {
+                        "nori_tokenizer": {
+                          "type": "nori_tokenizer",
+                          "decompound_mode": "mixed"
+                        }
+                      }
+                    }
+                  },
+                  "mappings": {
+                    "properties": {
+                      "postId": {"type": "long"},
+                      "title": {
+                        "type": "text",
+                        "analyzer": "nori_analyzer",
+                        "fields": {
+                          "keyword": {"type": "keyword"}
+                        }
+                      },
+                      "content": {
+                        "type": "text",
+                        "analyzer": "nori_analyzer"
+                      },
+                      "viewCount": {"type": "integer"},
+                      "thumbImageUrl": {"type": "keyword"},
+                      "createdAt": {"type": "date"},
+                      "updatedAt": {"type": "date"},
+                      "authorId": {"type": "long"},
+                      "authorName": {
+                        "type": "text",
+                        "analyzer": "nori_analyzer",
+                        "fields": {
+                          "keyword": {"type": "keyword"}
+                        }
+                      }
+                    }
+                  }
+                }
+                """;
+
+            Request request = new Request("PUT", "/" + indexName);
+            request.setJsonEntity(mapping);
+            restClient.performRequest(request);
+            log.info("Posts index created successfully");
+        }
+    }
+
+    private void createDogsIndex() throws IOException {
+        String indexName = "dogs";
+
+        if (!indexExists(indexName)) {
+            String mapping = """
+                {
+                  "settings": {
+                    "analysis": {
+                      "analyzer": {
+                        "nori_analyzer": {
+                          "type": "custom",
+                          "tokenizer": "nori_tokenizer",
+                          "filter": ["lowercase", "nori_part_of_speech"]
+                        }
+                      },
+                      "tokenizer": {
+                        "nori_tokenizer": {
+                          "type": "nori_tokenizer",
+                          "decompound_mode": "mixed"
+                        }
+                      }
+                    }
+                  },
+                  "mappings": {
+                    "properties": {
+                      "dogId": {"type": "long"},
+                      "name": {
+                        "type": "text",
+                        "analyzer": "nori_analyzer",
+                        "fields": {
+                          "keyword": {"type": "keyword"}
+                        }
+                      },
+                      "breedName": {"type": "keyword"},
+                      "birthDate": {"type": "keyword"},
+                      "gender": {"type": "keyword"},
+                      "dogSize": {"type": "keyword"},
+                      "weight": {"type": "double"},
+                      "healthStatus": {
+                        "type": "text",
+                        "analyzer": "nori_analyzer"
+                      },
+                      "description": {
+                        "type": "text",
+                        "analyzer": "nori_analyzer"
+                      },
+                      "adoptionStatus": {"type": "keyword"},
+                      "createdAt": {"type": "date"},
+                      "updatedAt": {"type": "date"},
+                      "imageUrl": {"type": "keyword"},
+                      "memberId": {"type": "long"},
+                      "shelterId": {"type": "long"},
+                      "shelterName": {"type": "keyword"},
+                      "location": {"type": "keyword"}
+                    }
+                  }
+                }
+                """;
+
+            Request request = new Request("PUT", "/" + indexName);
+            request.setJsonEntity(mapping);
+            restClient.performRequest(request);
+            log.info("Dogs index created successfully");
+        }
+    }
+
+    private boolean indexExists(String indexName) {
+        try {
+            Request request = new Request("HEAD", "/" + indexName);
+            Response response = restClient.performRequest(request);
+            return response.getStatusLine().getStatusCode() == 200;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/example/petner/global/config/JacksonConfig.java
+++ b/src/main/java/com/example/petner/global/config/JacksonConfig.java
@@ -1,0 +1,21 @@
+package com.example.petner.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean("customObjectMapper")
+    @Primary
+    public ObjectMapper customObjectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return mapper;
+    }
+}

--- a/src/main/java/com/example/petner/global/config/OpenSearchConfig.java
+++ b/src/main/java/com/example/petner/global/config/OpenSearchConfig.java
@@ -1,0 +1,46 @@
+package com.example.petner.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.opensearch.client.RestClient;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.transport.rest_client.RestClientTransport;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.apache.http.HttpHost;
+
+@Configuration
+public class OpenSearchConfig {
+
+    @Value("${opensearch.host:localhost}")
+    private String host;
+
+    @Value("${opensearch.port:9200}")
+    private int port;
+
+    @Value("${opensearch.scheme:http}")
+    private String scheme;
+
+    @Bean
+    public RestClient restClient() {
+        return RestClient.builder(
+                new HttpHost(host, port, scheme)
+        ).build();
+    }
+
+    @Bean
+    public OpenSearchClient openSearchClient(RestClient restClient) {
+        // OpenSearch용 ObjectMapper에 JSR310 모듈 추가
+        ObjectMapper mapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        RestClientTransport transport = new RestClientTransport(
+                restClient, new JacksonJsonpMapper(mapper)
+        );
+        return new OpenSearchClient(transport);
+    }
+}

--- a/src/main/java/com/example/petner/search/document/DogDocument.java
+++ b/src/main/java/com/example/petner/search/document/DogDocument.java
@@ -1,0 +1,65 @@
+package com.example.petner.search.document;
+
+import com.example.petner.domain.dog.common.AdoptionStatus;
+import com.example.petner.domain.dog.common.DogSize;
+import com.example.petner.domain.dog.entity.Dog;
+import com.example.petner.global.config.common.Gender;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DogDocument {
+
+    private String id; // OpenSearch document ID (dogId를 문자열로)
+    private Long dogId;
+    private String name;
+    private String breedName;
+    private String birthDate;
+    private Gender gender;
+    private DogSize dogSize;
+    private BigDecimal weight;
+    private String healthStatus;
+    private String description;
+    private AdoptionStatus adoptionStatus;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    private String imageUrl;
+    private Long memberId;
+    private Long shelterId;
+    private String shelterName;
+    private String location; // shelter 위치 정보
+
+    public static DogDocument from(Dog dog) {
+        return DogDocument.builder()
+                .id(String.valueOf(dog.getDogId()))
+                .dogId(dog.getDogId())
+                .name(dog.getName())
+                .breedName(dog.getBreed().getName())
+                .birthDate(dog.getBirthDate())
+                .gender(dog.getGender())
+                .dogSize(dog.getDogSize())
+                .weight(dog.getWeight())
+                .healthStatus(dog.getHealthStatus())
+                .description(dog.getDescription())
+                .adoptionStatus(dog.getAdoptionStatus())
+                .createdAt(dog.getCreatedAt())
+                .updatedAt(dog.getUpdatedAt())
+                .imageUrl(dog.getImageUrl())
+                .memberId(dog.getMember().getMemberId())
+                .shelterId(dog.getShelter() != null ? dog.getShelter().getShelterId() : null)
+                .shelterName(dog.getShelter() != null ? dog.getShelter().getName() : null)
+                .location(dog.getShelter() != null && dog.getShelter().getLocation() != null ?
+                    dog.getShelter().getLocation().getState() + " " + dog.getShelter().getLocation().getDistrict() : null)
+                .build();
+    }
+}

--- a/src/main/java/com/example/petner/search/document/PostDocument.java
+++ b/src/main/java/com/example/petner/search/document/PostDocument.java
@@ -1,0 +1,60 @@
+package com.example.petner.search.document;
+
+import com.example.petner.domain.post.entity.Post;
+import com.example.petner.search.dto.PostSearchDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostDocument {
+
+    private String id; // OpenSearch document ID (postId를 문자열로)
+    private Long postId;
+    private String title;
+    private String content;
+    private Integer viewCount;
+    private String thumbImageUrl;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    private Long authorId;
+    private String authorName;
+
+    public static PostDocument from(Post post) {
+        return PostDocument.builder()
+                .id(String.valueOf(post.getPostId()))
+                .postId(post.getPostId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .viewCount(post.getViewCount())
+                .thumbImageUrl(post.getThumbImageUrl())
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .authorId(post.getAuthor().getMemberId())
+                .authorName(post.getAuthor().getNickname())
+                .build();
+    }
+
+    public static PostDocument from(PostSearchDto dto) {
+        return PostDocument.builder()
+                .id(String.valueOf(dto.getPostId()))
+                .postId(dto.getPostId())
+                .title(dto.getTitle())
+                .content(dto.getContent())
+                .viewCount(dto.getViewCount())
+                .thumbImageUrl(dto.getThumbImageUrl())
+                .createdAt(dto.getCreatedAt())
+                .updatedAt(dto.getUpdatedAt())
+                .authorId(dto.getAuthorId())
+                .authorName(dto.getAuthorName())
+                .build();
+    }
+}

--- a/src/main/java/com/example/petner/search/dto/PostSearchDto.java
+++ b/src/main/java/com/example/petner/search/dto/PostSearchDto.java
@@ -1,5 +1,6 @@
 package com.example.petner.search.dto;
 
+import com.example.petner.domain.post.entity.Post;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -18,4 +19,18 @@ public class PostSearchDto {
     private final LocalDateTime updatedAt;
     private final Long authorId;
     private final String authorName;
+
+    public static PostSearchDto from(Post post) {
+        return new PostSearchDto(
+                post.getPostId(),
+                post.getTitle(),
+                post.getContent(),
+                post.getViewCount(),
+                post.getThumbImageUrl(),
+                post.getCreatedAt(),
+                post.getUpdatedAt(),
+                post.getAuthor().getMemberId(),
+                post.getAuthor().getNickname()
+        );
+    }
 }

--- a/src/main/java/com/example/petner/search/dto/PostSearchDto.java
+++ b/src/main/java/com/example/petner/search/dto/PostSearchDto.java
@@ -1,0 +1,21 @@
+package com.example.petner.search.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class PostSearchDto {
+    private final Long postId;
+    private final String title;
+    private final String content;
+    private final Integer viewCount;
+    private final String thumbImageUrl;
+
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+    private final Long authorId;
+    private final String authorName;
+}

--- a/src/main/java/com/example/petner/search/event/PostEvent.java
+++ b/src/main/java/com/example/petner/search/event/PostEvent.java
@@ -1,0 +1,27 @@
+package com.example.petner.search.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PostEvent {
+    private final Long postId;
+    private final EventType eventType;
+
+    public static PostEvent created(Long postId) {
+        return new PostEvent(postId, EventType.CREATED);
+    }
+
+    public static PostEvent updated(Long postId) {
+        return new PostEvent(postId, EventType.UPDATED);
+    }
+
+    public static PostEvent deleted(Long postId) {
+        return new PostEvent(postId, EventType.DELETED);
+    }
+
+    public enum EventType {
+        CREATED, UPDATED, DELETED
+    }
+}

--- a/src/main/java/com/example/petner/search/listener/SearchSyncListener.java
+++ b/src/main/java/com/example/petner/search/listener/SearchSyncListener.java
@@ -1,5 +1,6 @@
 package com.example.petner.search.listener;
 
+import com.example.petner.domain.post.entity.Post;
 import com.example.petner.domain.post.repository.PostRepository;
 import com.example.petner.search.document.PostDocument;
 import com.example.petner.search.dto.PostSearchDto;
@@ -40,9 +41,10 @@ public class SearchSyncListener {
     }
 
     private void syncPostToSearch(Long postId) throws IOException {
-        PostSearchDto postDto = postRepository.findPostForSearch(postId)
+        Post post = postRepository.findByIdWithAuthor(postId)
                 .orElseThrow(() -> new IllegalArgumentException("Post not found: " + postId));
 
+        PostSearchDto postDto = PostSearchDto.from(post);
         PostDocument document = PostDocument.from(postDto);
         postSearchRepository.save(document);
 

--- a/src/main/java/com/example/petner/search/listener/SearchSyncListener.java
+++ b/src/main/java/com/example/petner/search/listener/SearchSyncListener.java
@@ -1,0 +1,56 @@
+package com.example.petner.search.listener;
+
+import com.example.petner.domain.post.repository.PostRepository;
+import com.example.petner.search.document.PostDocument;
+import com.example.petner.search.dto.PostSearchDto;
+import com.example.petner.search.event.PostEvent;
+import com.example.petner.search.repository.PostSearchRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SearchSyncListener {
+
+    private final PostSearchRepository postSearchRepository;
+    private final PostRepository postRepository;
+
+    @TransactionalEventListener
+    @Async("searchSyncExecutor")
+    public void handlePostEvent(PostEvent event) {
+        try {
+            switch (event.getEventType()) {
+                case CREATED:
+                case UPDATED:
+                    syncPostToSearch(event.getPostId());
+                    break;
+                case DELETED:
+                    deletePostFromSearch(event.getPostId());
+                    break;
+            }
+        } catch (Exception e) {
+            log.error("Failed to sync post search data for postId: {}", event.getPostId(), e);
+        }
+    }
+
+    private void syncPostToSearch(Long postId) throws IOException {
+        PostSearchDto postDto = postRepository.findPostForSearch(postId)
+                .orElseThrow(() -> new IllegalArgumentException("Post not found: " + postId));
+
+        PostDocument document = PostDocument.from(postDto);
+        postSearchRepository.save(document);
+
+        log.info("Post synced to search: {}", postId);
+    }
+
+    private void deletePostFromSearch(Long postId) throws IOException {
+        postSearchRepository.delete(String.valueOf(postId));
+        log.info("Post deleted from search: {}", postId);
+    }
+}

--- a/src/main/java/com/example/petner/search/repository/PostSearchRepository.java
+++ b/src/main/java/com/example/petner/search/repository/PostSearchRepository.java
@@ -1,0 +1,95 @@
+package com.example.petner.search.repository;
+
+import com.example.petner.search.document.PostDocument;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.SortOptions;
+import org.opensearch.client.opensearch._types.SortOrder;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch.core.*;
+import org.opensearch.client.opensearch.core.search.Hit;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Repository
+public class PostSearchRepository {
+
+    private static final String INDEX_NAME = "posts";
+
+    @Autowired
+    private OpenSearchClient openSearchClient;
+
+    public void save(PostDocument document) throws IOException {
+        IndexRequest<PostDocument> request = IndexRequest.of(i -> i
+                .index(INDEX_NAME)
+                .id(document.getId())
+                .document(document)
+        );
+        openSearchClient.index(request);
+    }
+
+    public void delete(String id) throws IOException {
+        DeleteRequest request = DeleteRequest.of(d -> d
+                .index(INDEX_NAME)
+                .id(id)
+        );
+        openSearchClient.delete(request);
+    }
+
+    public Optional<PostDocument> findById(String id) throws IOException {
+        GetRequest request = GetRequest.of(g -> g
+                .index(INDEX_NAME)
+                .id(id)
+        );
+
+        GetResponse<PostDocument> response = openSearchClient.get(request, PostDocument.class);
+        return response.found() ? Optional.of(response.source()) : Optional.empty();
+    }
+
+    public List<PostDocument> searchByKeyword(String keyword, String sortBy, int from, int size) throws IOException {
+        Query query = keyword != null && !keyword.trim().isEmpty()
+            ? Query.of(q -> q.multiMatch(m -> m
+                .query(keyword)
+                .fields("title^2", "content", "authorName")
+                .analyzer("nori_analyzer")
+            ))
+            : Query.of(q -> q.matchAll(m -> m));
+
+        // 정렬 로직 시작
+        List<SortOptions> sortOptions = new ArrayList<>();
+
+        switch (sortBy) {
+            case "latest":
+                sortOptions.add(SortOptions.of(so -> so.field(f -> f.field("createdAt").order(SortOrder.Desc))));
+                break;
+            case "oldest":
+                sortOptions.add(SortOptions.of(so -> so.field(f -> f.field("createdAt").order(SortOrder.Asc))));
+                break;
+            case "viewCount":
+                sortOptions.add(SortOptions.of(so -> so.field(f -> f.field("viewCount").order(SortOrder.Desc))));
+                sortOptions.add(SortOptions.of(so -> so.field(f -> f.field("createdAt").order(SortOrder.Desc))));
+                break;
+            default:
+                sortOptions.add(SortOptions.of(so -> so.field(f -> f.field("createdAt").order(SortOrder.Desc))));
+                break;
+        }
+
+        SearchRequest request = SearchRequest.of(s -> s
+                .index(INDEX_NAME)
+                .query(query)
+                .from(from)
+                .size(size)
+                .sort(sortOptions)
+        );
+
+        SearchResponse<PostDocument> response = openSearchClient.search(request, PostDocument.class);
+        return response.hits().hits().stream()
+                .map(Hit::source)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/petner/search/service/PostSearchService.java
+++ b/src/main/java/com/example/petner/search/service/PostSearchService.java
@@ -1,0 +1,28 @@
+package com.example.petner.search.service;
+
+import com.example.petner.search.document.PostDocument;
+import com.example.petner.search.repository.PostSearchRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PostSearchService {
+
+    private final PostSearchRepository postSearchRepository;
+
+    public List<PostDocument> searchPosts(String keyword, String sortBy, int page, int size) {
+        try {
+            int from = page * size;
+            return postSearchRepository.searchByKeyword(keyword, sortBy, from, size);
+        } catch (IOException e) {
+            log.error("Failed to search posts", e);
+            throw new RuntimeException("검색 중 오류가 발생했습니다.", e);
+        }
+    }
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -58,3 +58,8 @@ cookie.secure=${COOKIE_SECURE}
 kakao.oauth.client-id=${KAKAO_CLIENT_ID}
 kakao.oauth.client-secret=${KAKAO_CLIENT_SECRET}
 kakao.oauth.redirect-uri=${KAKAO_REDIRECT_URI}
+
+# OpenSearch Configuration
+opensearch.host=${OPENSEARCH_HOST}
+opensearch.port=${OPENSEARCH_PORT}
+opensearch.protocol=${OPENSEARCH_PROTOCOL}


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
도메인 로직과 검색 로직의 결합도를 낮추고 데이터 정합성을 보장하기 위해, Spring의 `ApplicationEventPublisher`를 사용한 이벤트 기반 비동기 아키텍처를 적용했습니다.

주요 구현 내용은 다음과 같습니다.

안정적인 데이터 동기화:
- `Post` 엔티티의 생성/수정/삭제가 발생할 때, `@TransactionalEventListener`를 사용하여 DB 트랜잭션이 성공적으로 커밋된 후에만 OpenSearch 동기화 이벤트를 비동기로 처리합니다. 이를 통해 데이터 불일치 가능성을 최소화했습니다.

모듈 분리:
- 검색 관련 로직을 `com.petner.search` 모듈로 완전히 분리하여, 기존 도메인 코드에 미치는 영향을 최소화하고 향후 유지보수성을 높였습니다.

검색 API 구현:
- `GET /api/v1/posts/search` API 엔드포인트를 통해 키워드(`q`), 정렬 조건(`sort`), 페이징(`page`, `size`)에 따른 동적인 검색 결과를 제공합니다.

주요 트러블슈팅: `LocalDateTime` 직렬화 오류 해결
- 문제1: `OpenSearch Client`가 `LocalDateTime` 필드를 JSON으로 변환하지 못하는 `JsonParseException`이 발생했습니다.
  - 원인1: `Spring Boot`의 전역 `ObjectMapper` 설정과 별개로, `OpenSearch Java Client`가 내부적으로 사용하는 독립적인 `ObjectMapper` 인스턴스에 `JavaTimeModule`이 등록되지 않았기 때문입니다.
  - 해결1: 전역 설정을 변경할 경우 발생할 수 있는 사이드 이펙트를 방지하기 위해, 문제가 발생한 `PostDocument`와 `PostSearchDto`의 `LocalDateTime` 필드에 `@JsonFormat` 어노테이션을 직접 추가하여 포맷을 명시하는 방식으로 문제를 해결했습니다.
- 문제2: `Post` 부분에서 `LocalDateTime` 필드를 JSON으로 변환하지 못하는 `JsonParseException`이 발생하였습니다.
  - 해결2: 기존 `@JsonFormat` 어노테이션을 사용한 임시적인 해결책을 제거하고, 전역 `CustomObjectMapper` 설정을 통해 애플리케이션 전반의 `LocalDateTime` 직렬화 문제를 근본적으로 해결합니다. 이를 통해 향후 `LocalDateTime` 필드를 사용하는 모든 DTO에서 발생할 수 있는 잠재적인 직렬화 오류를 원천 차단하고, 날짜/시간 데이터 포맷의 일관성을 확보합니다.

참고: OpenSearch 연결에 필요한 `opensearch.host`, `opensearch.port` 등의 환경 변수 설정에 대한 자세한 내용은 _**팀 내 공유 문서에 있습니다.**_

# 연관 이슈 및 Close 할 이슈 작성
<!--이슈 번호를 적어주세요(예시: fix #123). -->

#21

close #21

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가? (API 테스트 및 OpenSearch 데이터 동기화 확인 완료)
- [x] 의미 있는 커밋 메시지를 작성했는가?