### PR TITLE
[Feature] 세션 공통 모듈 개발-feature/ddd-31

### DIFF
--- a/src/main/java/com/example/petner/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/petner/domain/auth/controller/AuthController.java
@@ -5,6 +5,8 @@ import com.example.petner.domain.auth.dto.response.LogoutResponse;
 import com.example.petner.domain.auth.dto.response.MemberResponse;
 import com.example.petner.domain.auth.dto.response.SessionResponse;
 import com.example.petner.domain.auth.service.AuthService;
+import com.example.petner.global.annotation.SessionMember;
+import com.example.petner.global.dto.SessionUser;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -69,14 +71,28 @@ public class AuthController {
     }
 
     @GetMapping("/member")
-    public ResponseEntity<MemberResponse> getCurrentMember(HttpSession session) {
-        MemberResponse member = authService.getCurrentMember(session);
+    public ResponseEntity<MemberResponse> getCurrentMember(@SessionMember SessionUser user) {
+        // @SessionMember로 자동 주입받은 SessionUser에서 바로 MemberResponse 생성
+        MemberResponse member = MemberResponse.builder()
+                .memberId(user.getMemberId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .gender(user.getGender())
+                .housingType(user.getHousingType())
+                .contact(user.getContact())
+                .locationId(user.getLocationId())
+                .state(user.getState())
+                .district(user.getDistrict())
+                .locationName(user.getLocationName())
+                .profileCompleted(user.isProfileCompleted())
+                .build();
         return ResponseEntity.ok(member);
     }
 
     @GetMapping("/session")
-    public ResponseEntity<SessionResponse> checkAuthentication(HttpSession session) {
-        SessionResponse sessionStatus = authService.getSessionStatus(session);
-        return ResponseEntity.ok(sessionStatus);
+    public ResponseEntity<SessionResponse> checkAuthentication(@SessionMember(required = false) SessionUser user) {
+        boolean isAuthenticated = user != null;
+        return ResponseEntity.ok(isAuthenticated ? SessionResponse.authenticated() : SessionResponse.unauthenticated());
     }
+    
 }

--- a/src/main/java/com/example/petner/domain/auth/dto/response/MemberResponse.java
+++ b/src/main/java/com/example/petner/domain/auth/dto/response/MemberResponse.java
@@ -14,15 +14,32 @@ public class MemberResponse {
     private String nickname;
     private Gender gender;
     private HousingType housingType;
+    private String contact;
+    private Long locationId;
+    private String state;
+    private String district;
+    private String locationName; // 조합된 지역명
     private boolean profileCompleted;
 
     public static MemberResponse from(Member member) {
+        String locationName = null;
+        if (member.getLocation() != null && 
+            member.getLocation().getState() != null && 
+            member.getLocation().getDistrict() != null) {
+            locationName = member.getLocation().getState() + " " + member.getLocation().getDistrict();
+        }
+        
         return MemberResponse.builder()
                 .memberId(member.getMemberId())
                 .email(member.getEmail())
                 .nickname(member.getNickname())
                 .gender(member.getGender())
                 .housingType(member.getHousingType())
+                .contact(member.getContact())
+                .locationId(member.getLocation() != null ? member.getLocation().getLocationId() : null)
+                .state(member.getLocation() != null ? member.getLocation().getState() : null)
+                .district(member.getLocation() != null ? member.getLocation().getDistrict() : null)
+                .locationName(locationName)
                 .profileCompleted(member.isProfileComplete())
                 .build();
     }

--- a/src/main/java/com/example/petner/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/petner/domain/auth/service/AuthService.java
@@ -7,9 +7,11 @@ import com.example.petner.domain.auth.dto.response.MemberResponse;
 import com.example.petner.domain.auth.dto.response.SessionResponse;
 import com.example.petner.domain.member.entity.Member;
 import com.example.petner.domain.member.service.MemberService;
+import com.example.petner.global.dto.SessionUser;
 import com.example.petner.global.exception.ErrorCode;
 import com.example.petner.global.exception.customException.MemberException;
 import com.example.petner.domain.auth.client.OAuthApiClient;
+import com.example.petner.global.util.SessionUtils;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,9 +26,8 @@ public class AuthService {
 
     private final OAuthApiClient oAuthApiClient;
     private final MemberService memberService;
-    
-    private static final String SESSION_MEMBER_KEY = "member";
 
+    @Transactional
     public LoginResponse kakaoLogin(String authorizationCode, HttpSession session) {
         // 외부 API 호출
         String accessToken = oAuthApiClient.getAccessToken(authorizationCode);
@@ -35,7 +36,8 @@ public class AuthService {
         // 회원 찾기 또는 생성 (MemberService에서 트랜잭션 처리)
         Member member = memberService.findOrCreateMember(kakaoUserInfo);
         
-        session.setAttribute(SESSION_MEMBER_KEY, member.getMemberId());
+        // 세션에 사용자 정보 저장
+        SessionUtils.setSessionUser(session, member);
         
         String maskedKakaoId = kakaoUserInfo.getKakaoId().length() > 4 ? 
             kakaoUserInfo.getKakaoId().substring(0, 4) + "****" : "****";
@@ -50,11 +52,11 @@ public class AuthService {
 
     public LogoutResponse logout(HttpSession session) {
         try {
-            Long memberId = (Long) session.getAttribute(SESSION_MEMBER_KEY);
+            Long memberId = SessionUtils.getCurrentMemberId(session);
             if (memberId != null) {
                 log.info("[로그아웃] 완료: memberId={}", memberId);
             }
-            session.invalidate();
+            SessionUtils.clearSession(session);
             return LogoutResponse.success();
         } catch (Exception e) {
             log.warn("[로그아웃] 세션 무효화 실패", e);
@@ -63,17 +65,35 @@ public class AuthService {
     }
 
     public MemberResponse getCurrentMember(HttpSession session) {
-        Long memberId = (Long) session.getAttribute(SESSION_MEMBER_KEY);
-        if (memberId == null) {
-            throw new MemberException(ErrorCode.UNAUTHORIZED_ACCESS);
+        // SessionUser 캐시에서 먼저 조회 시도
+        SessionUser sessionUser = SessionUtils.getCurrentUser(session)
+                .orElse(null);
+        
+        if (sessionUser != null) {
+            // 캐시된 정보로 MemberResponse 생성 (DB 조회 없음)
+            return MemberResponse.builder()
+                    .memberId(sessionUser.getMemberId())
+                    .email(sessionUser.getEmail())
+                    .nickname(sessionUser.getNickname())
+                    .gender(sessionUser.getGender())
+                    .housingType(sessionUser.getHousingType())
+                    .contact(sessionUser.getContact())
+                    .locationId(sessionUser.getLocationId())
+                    .state(sessionUser.getState())
+                    .district(sessionUser.getDistrict())
+                    .locationName(sessionUser.getLocationName())
+                    .profileCompleted(sessionUser.isProfileCompleted())
+                    .build();
         }
-
+        
+        // 캐시가 없으면 기존 방식으로 폴백 (DB 조회)
+        Long memberId = SessionUtils.requireCurrentMemberId(session);
         Member member = memberService.findById(memberId);
         return MemberResponse.from(member);
     }
 
     public SessionResponse getSessionStatus(HttpSession session) {
-        boolean isAuthenticated = session.getAttribute(SESSION_MEMBER_KEY) != null;
+        boolean isAuthenticated = SessionUtils.isAuthenticated(session);
         return isAuthenticated ? SessionResponse.authenticated() : SessionResponse.unauthenticated();
     }
 }

--- a/src/main/java/com/example/petner/global/annotation/SessionMember.java
+++ b/src/main/java/com/example/petner/global/annotation/SessionMember.java
@@ -1,0 +1,42 @@
+package com.example.petner.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 세션에서 현재 로그인한 사용자 정보를 자동으로 주입하는 애노테이션
+ * 
+ * 사용 예시:
+ * <pre>
+ * {@code
+ * @GetMapping("/my-profile")
+ * public ResponseEntity<?> getMyProfile(@SessionMember SessionUser user) {
+ *     // user 파라미터에 현재 로그인 사용자 정보가 자동으로 주입됨
+ *     return ResponseEntity.ok(user.getNickname());
+ * }
+ * 
+ * @PostMapping("/optional-api")
+ * public ResponseEntity<?> optionalApi(@SessionMember(required = false) SessionUser user) {
+ *     // 로그인하지 않은 경우 user는 null
+ *     if (user != null) {
+ *         return ResponseEntity.ok("로그인 사용자");
+ *     } else {
+ *         return ResponseEntity.ok("게스트 사용자");
+ *     }
+ * }
+ * }
+ * </pre>
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SessionMember {
+    
+    /**
+     * 인증 필수 여부
+     * @return true: 인증되지 않은 경우 MemberException(UNAUTHORIZED_ACCESS) 발생
+     *         false: 인증되지 않은 경우 null 반환
+     */
+    boolean required() default true;
+}

--- a/src/main/java/com/example/petner/global/config/Swagger/SwaggerConfig.java
+++ b/src/main/java/com/example/petner/global/config/Swagger/SwaggerConfig.java
@@ -1,12 +1,17 @@
 package com.example.petner.global.config.Swagger;
 
+import com.example.petner.global.annotation.SessionMember;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.HandlerMethod;
+
+import java.lang.reflect.Parameter;
 
 /**
  * Swagger springdoc-ui 구성 파일
@@ -43,5 +48,29 @@ public class SwaggerConfig {
                         .type(SecurityScheme.Type.APIKEY)
                         .in(SecurityScheme.In.COOKIE)
                         .description("세션 쿠키 인증. 브라우저에서 로그인 후 자동으로 설정됩니다."));
+    }
+    
+    /**
+     * @SessionMember 파라미터를 스웨거에서 숨기는 customizer
+     */
+    @Bean
+    public OperationCustomizer operationCustomizer() {
+        return (operation, handlerMethod) -> {
+            // 메서드의 모든 파라미터 검사
+            Parameter[] parameters = handlerMethod.getMethod().getParameters();
+            
+            for (int i = 0; i < parameters.length; i++) {
+                Parameter parameter = parameters[i];
+                
+                // @SessionMember 애노테이션이 있는 파라미터는 스웨거에서 제거
+                if (parameter.isAnnotationPresent(SessionMember.class)) {
+                    if (operation.getParameters() != null && i < operation.getParameters().size()) {
+                        operation.getParameters().remove(i);
+                    }
+                }
+            }
+            
+            return operation;
+        };
     }
 }

--- a/src/main/java/com/example/petner/global/config/Swagger/SwaggerConfig.java
+++ b/src/main/java/com/example/petner/global/config/Swagger/SwaggerConfig.java
@@ -30,20 +30,18 @@ public class SwaggerConfig {
     }
     /**
      * Swagger 보안 설정
-     * JWT 토큰 인증을 위한 설정
+     * 세션 쿠키 인증을 위한 설정
      */
     private SecurityRequirement securityRequirement() {
-        return new SecurityRequirement().addList("JWT");
+        return new SecurityRequirement().addList("SESSION");
     }
 
     private Components components() {
         return new Components()
-                .addSecuritySchemes("JWT", new SecurityScheme()
-                        .name("JWT")
-                        .type(SecurityScheme.Type.HTTP)
-                        .scheme("bearer")
-                        .bearerFormat("JWT")
-                        .in(SecurityScheme.In.HEADER)
-                        .description("JWT 토큰을 입력하세요. 'Bearer ' 접두사는 자동으로 추가됩니다."));
+                .addSecuritySchemes("SESSION", new SecurityScheme()
+                        .name("SESSION")
+                        .type(SecurityScheme.Type.APIKEY)
+                        .in(SecurityScheme.In.COOKIE)
+                        .description("세션 쿠키 인증. 브라우저에서 로그인 후 자동으로 설정됩니다."));
     }
 }

--- a/src/main/java/com/example/petner/global/config/WebConfig.java
+++ b/src/main/java/com/example/petner/global/config/WebConfig.java
@@ -1,0 +1,34 @@
+package com.example.petner.global.config;
+
+import com.example.petner.global.resolver.SessionMemberArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+/**
+ * Web MVC 설정
+ * 
+ * 주요 기능:
+ * - ArgumentResolver 등록: @SessionMember 애노테이션 지원
+ * - 향후 추가될 수 있는 다른 웹 설정들
+ */
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final SessionMemberArgumentResolver sessionMemberArgumentResolver;
+
+    /**
+     * ArgumentResolver 등록
+     * @SessionMember 애노테이션이 붙은 파라미터에 SessionUser를 자동 주입
+     * 
+     * @param resolvers ArgumentResolver 목록
+     */
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(sessionMemberArgumentResolver);
+    }
+}

--- a/src/main/java/com/example/petner/global/dto/SessionUser.java
+++ b/src/main/java/com/example/petner/global/dto/SessionUser.java
@@ -27,19 +27,39 @@ public class SessionUser implements Serializable {
     private final String district;
     private final boolean profileCompleted;
     
+    /**
+     * Member 엔티티로부터 SessionUser 생성
+     * @param member Member 엔티티
+     * @return SessionUser 인스턴스
+     * @throws IllegalArgumentException member가 null이거나 필수 필드가 null인 경우
+     */
     public static SessionUser from(Member member) {
-        return SessionUser.builder()
-                .memberId(member.getMemberId())
-                .nickname(member.getNickname())
-                .email(member.getEmail())
-                .gender(member.getGender())
-                .housingType(member.getHousingType())
-                .contact(member.getContact())
-                .locationId(member.getLocation() != null ? member.getLocation().getLocationId() : null)
-                .state(member.getLocation() != null ? member.getLocation().getState() : null)
-                .district(member.getLocation() != null ? member.getLocation().getDistrict() : null)
-                .profileCompleted(member.isProfileComplete())
-                .build();
+        if (member == null) {
+            throw new IllegalArgumentException("Member는 null일 수 없습니다");
+        }
+        
+        // 필수 필드 검증 (memberId만 필수, 나머지는 nullable)
+        if (member.getMemberId() == null) {
+            throw new IllegalArgumentException("Member의 ID는 null일 수 없습니다");
+        }
+        
+        try {
+            return SessionUser.builder()
+                    .memberId(member.getMemberId())
+                    .nickname(member.getNickname())
+                    .email(member.getEmail())
+                    .gender(member.getGender())
+                    .housingType(member.getHousingType())
+                    .contact(member.getContact())
+                    .locationId(member.getLocation() != null ? member.getLocation().getLocationId() : null)
+                    .state(member.getLocation() != null ? member.getLocation().getState() : null)
+                    .district(member.getLocation() != null ? member.getLocation().getDistrict() : null)
+                    .profileCompleted(member.isProfileComplete())
+                    .build();
+        } catch (Exception e) {
+            // 지연 로딩 오류나 기타 JPA 관련 오류
+            throw new IllegalArgumentException("Member 정보를 SessionUser로 변환하는 중 오류가 발생했습니다", e);
+        }
     }
     
     /**

--- a/src/main/java/com/example/petner/global/dto/SessionUser.java
+++ b/src/main/java/com/example/petner/global/dto/SessionUser.java
@@ -1,0 +1,55 @@
+package com.example.petner.global.dto;
+
+import com.example.petner.domain.member.entity.Member;
+import com.example.petner.domain.member.common.HousingType;
+import com.example.petner.global.config.common.Gender;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+@Getter
+@Builder
+public class SessionUser implements Serializable {
+    
+    @Serial
+    private static final long serialVersionUID = 1L;
+    
+    private final Long memberId;
+    private final String nickname;
+    private final String email;
+    private final Gender gender;
+    private final HousingType housingType;
+    private final String contact;
+    private final Long locationId;
+    private final String state;
+    private final String district;
+    private final boolean profileCompleted;
+    
+    public static SessionUser from(Member member) {
+        return SessionUser.builder()
+                .memberId(member.getMemberId())
+                .nickname(member.getNickname())
+                .email(member.getEmail())
+                .gender(member.getGender())
+                .housingType(member.getHousingType())
+                .contact(member.getContact())
+                .locationId(member.getLocation() != null ? member.getLocation().getLocationId() : null)
+                .state(member.getLocation() != null ? member.getLocation().getState() : null)
+                .district(member.getLocation() != null ? member.getLocation().getDistrict() : null)
+                .profileCompleted(member.isProfileComplete())
+                .build();
+    }
+    
+    /**
+     * 지역 정보를 문자열로 조합
+     * @return "서울특별시 강남구" 형태의 지역명
+     */
+    public String getLocationName() {
+        if (state != null && district != null) {
+            return state + " " + district;
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/petner/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/petner/global/exception/ErrorCode.java
@@ -13,6 +13,8 @@ public enum ErrorCode {
     UNAUTHORIZED_ACCESS("401-AU02", "인증이 필요합니다.", HttpStatus.UNAUTHORIZED),
     KAKAO_AUTH_FAILED("401-AU03", "카카오 인증에 실패했습니다.", HttpStatus.UNAUTHORIZED),
     KAKAO_API_ERROR("500-AU04", "카카오 API 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    SESSION_DATA_CORRUPTED("500-AU05", "세션 데이터가 손상되었습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    SESSION_INVALID_DATA("400-AU06", "세션 데이터 형식이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
 
     /* 서버 에러 */
     GLOBAL_ERROR("500-GL01", "서버 오류", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/main/java/com/example/petner/global/resolver/SessionMemberArgumentResolver.java
+++ b/src/main/java/com/example/petner/global/resolver/SessionMemberArgumentResolver.java
@@ -1,0 +1,131 @@
+package com.example.petner.global.resolver;
+
+import com.example.petner.global.annotation.SessionMember;
+import com.example.petner.global.dto.SessionUser;
+import com.example.petner.global.exception.customException.MemberException;
+import com.example.petner.global.util.SessionUtils;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+/**
+ * @SessionMember 애노테이션이 붙은 파라미터에 현재 로그인 사용자 정보를 자동으로 주입하는 ArgumentResolver
+ * 
+ * 동작 방식:
+ * 1. @SessionMember 애노테이션이 있는 파라미터 감지
+ * 2. HttpSession에서 SessionUser 정보 조회
+ * 3. required=true면 인증 필수, required=false면 인증 선택적
+ * 4. SessionUser 객체를 컨트롤러 메서드에 자동 주입
+ */
+@Slf4j
+@Component
+public class SessionMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    /**
+     * 이 ArgumentResolver가 처리할 파라미터인지 판단
+     * @param parameter 메서드 파라미터 정보
+     * @return @SessionMember 애노테이션이 있고 SessionUser 타입이면 true
+     */
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        if (parameter == null) {
+            log.error("MethodParameter가 null입니다");
+            return false;
+        }
+        
+        try {
+            boolean hasAnnotation = parameter.hasParameterAnnotation(SessionMember.class);
+            boolean isSessionUserType = SessionUser.class.isAssignableFrom(parameter.getParameterType());
+            
+            if (hasAnnotation && !isSessionUserType) {
+                log.warn("@SessionMember 애노테이션은 SessionUser 타입 파라미터에만 사용 가능합니다. " +
+                        "현재 타입: {}, 메서드: {}", 
+                        parameter.getParameterType() != null ? parameter.getParameterType().getSimpleName() : "null",
+                        parameter.getMethod());
+            }
+            
+            return hasAnnotation && isSessionUserType;
+        } catch (Exception e) {
+            log.error("supportsParameter 처리 중 오류 발생", e);
+            return false;
+        }
+    }
+
+    /**
+     * 실제 파라미터 값을 해결(resolve)하는 메서드
+     * @param parameter 메서드 파라미터 정보
+     * @param mavContainer ModelAndView 컨테이너
+     * @param webRequest 웹 요청 객체
+     * @param binderFactory 데이터 바인더 팩토리
+     * @return SessionUser 객체 또는 null
+     * @throws MemberException 인증 실패 시
+     */
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                ModelAndViewContainer mavContainer,
+                                NativeWebRequest webRequest,
+                                WebDataBinderFactory binderFactory) {
+        
+        // 파라미터 검증
+        if (parameter == null) {
+            log.error("MethodParameter가 null입니다");
+            throw new RuntimeException("내부 오류가 발생했습니다");
+        }
+        
+        if (webRequest == null) {
+            log.error("NativeWebRequest가 null입니다");
+            throw new RuntimeException("내부 오류가 발생했습니다");
+        }
+        
+        // HTTP 요청에서 세션 추출
+        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        if (request == null) {
+            log.error("HttpServletRequest를 가져올 수 없습니다");
+            throw new RuntimeException("내부 오류가 발생했습니다");
+        }
+        
+        HttpSession session = request.getSession(false);
+        SessionMember annotation = parameter.getParameterAnnotation(SessionMember.class);
+        
+        if (annotation == null) {
+            log.error("@SessionMember 애노테이션을 찾을 수 없습니다 - 메서드: {}", 
+                     parameter.getMethod());
+            throw new RuntimeException("내부 오류가 발생했습니다");
+        }
+        
+        // 세션에서 사용자 정보 조회
+        SessionUser sessionUser = null;
+        try {
+            if (annotation.required()) {
+                // 인증 필수: 없으면 예외 발생
+                sessionUser = SessionUtils.requireCurrentUser(session);
+                log.debug("@SessionMember 인증 필수 모드: 사용자 정보 주입 완료 (memberId: {})", 
+                         sessionUser.getMemberId());
+            } else {
+                // 인증 선택적: 없으면 null 반환
+                sessionUser = SessionUtils.getCurrentUser(session).orElse(null);
+                log.debug("@SessionMember 선택적 모드: 사용자 정보 주입 완료 (memberId: {})", 
+                         sessionUser != null ? sessionUser.getMemberId() : "null");
+            }
+        } catch (MemberException e) {
+            log.debug("@SessionMember 인증 실패: {} (required={})", e.getErrorCode().getMessage(), annotation.required());
+            if (annotation.required()) {
+                // required=true인 경우 예외를 다시 던짐 (GlobalExceptionHandler에서 401 응답 처리)
+                throw e;
+            }
+            // required=false인 경우 null 반환
+            return null;
+        } catch (Exception e) {
+            log.error("@SessionMember 처리 중 예기치 못한 오류 발생", e);
+            throw new RuntimeException("내부 오류가 발생했습니다", e);
+        }
+        
+        return sessionUser;
+    }
+}

--- a/src/main/java/com/example/petner/global/util/SessionUtils.java
+++ b/src/main/java/com/example/petner/global/util/SessionUtils.java
@@ -22,25 +22,50 @@ public final class SessionUtils {
      * 현재 로그인한 사용자 ID 조회
      * @param session HTTP 세션
      * @return 사용자 ID (미인증 시 null)
+     * @throws MemberException 세션 데이터가 손상된 경우
      */
     public static Long getCurrentMemberId(HttpSession session) {
         if (session == null) {
             return null;
         }
-        return (Long) session.getAttribute(SESSION_MEMBER_KEY);
+        
+        try {
+            Object memberIdObj = session.getAttribute(SESSION_MEMBER_KEY);
+            if (memberIdObj == null) {
+                return null;
+            }
+            return (Long) memberIdObj;
+        } catch (ClassCastException e) {
+            // 세션 데이터가 Long이 아닌 경우 (데이터 손상)
+            throw new MemberException(ErrorCode.SESSION_DATA_CORRUPTED);
+        }
     }
     
     /**
      * 현재 로그인한 사용자 정보 조회 (캐싱된 정보)
      * @param session HTTP 세션
      * @return SessionUser (미인증 시 empty)
+     * @throws MemberException 세션 데이터가 손상된 경우
      */
     public static Optional<SessionUser> getCurrentUser(HttpSession session) {
         if (session == null) {
             return Optional.empty();
         }
-        SessionUser sessionUser = (SessionUser) session.getAttribute(SESSION_USER_KEY);
-        return Optional.ofNullable(sessionUser);
+        
+        try {
+            Object sessionUserObj = session.getAttribute(SESSION_USER_KEY);
+            if (sessionUserObj == null) {
+                return Optional.empty();
+            }
+            SessionUser sessionUser = (SessionUser) sessionUserObj;
+            return Optional.of(sessionUser);
+        } catch (ClassCastException e) {
+            // 세션 데이터가 SessionUser가 아닌 경우 (데이터 손상)
+            throw new MemberException(ErrorCode.SESSION_DATA_CORRUPTED);
+        } catch (Exception e) {
+            // 직렬화/역직렬화 오류 등
+            throw new MemberException(ErrorCode.SESSION_INVALID_DATA);
+        }
     }
     
     /**
@@ -90,10 +115,14 @@ public final class SessionUtils {
      * 로그인 처리 - 세션에 사용자 정보 저장
      * @param session HTTP 세션
      * @param member 로그인한 사용자
+     * @throws MemberException 세션 또는 멤버가 null인 경우
      */
     public static void setSessionUser(HttpSession session, Member member) {
-        if (session == null || member == null) {
-            return;
+        if (session == null) {
+            throw new MemberException(ErrorCode.GLOBAL_ERROR);
+        }
+        if (member == null) {
+            throw new MemberException(ErrorCode.MEMBER_NOT_FOUND);
         }
         
         session.setAttribute(SESSION_MEMBER_KEY, member.getMemberId());
@@ -104,12 +133,33 @@ public final class SessionUtils {
      * 세션 사용자 정보 갱신 (프로필 수정 시 사용)
      * @param session HTTP 세션
      * @param memberService 멤버 서비스
+     * @throws MemberException 세션이 null이거나 인증되지 않은 경우, 멤버를 찾을 수 없는 경우
      */
     public static void refreshSessionUser(HttpSession session, MemberService memberService) {
+        if (session == null) {
+            throw new MemberException(ErrorCode.GLOBAL_ERROR);
+        }
+        if (memberService == null) {
+            throw new MemberException(ErrorCode.GLOBAL_ERROR);
+        }
+        
         Long memberId = getCurrentMemberId(session);
-        if (memberId != null) {
+        if (memberId == null) {
+            throw new MemberException(ErrorCode.UNAUTHORIZED_ACCESS);
+        }
+        
+        try {
             Member member = memberService.findById(memberId);
+            if (member == null) {
+                throw new MemberException(ErrorCode.MEMBER_NOT_FOUND);
+            }
             session.setAttribute(SESSION_USER_KEY, SessionUser.from(member));
+        } catch (MemberException e) {
+            // MemberException은 그대로 전파
+            throw e;
+        } catch (Exception e) {
+            // 기타 예외는 서버 오류로 처리
+            throw new MemberException(ErrorCode.GLOBAL_ERROR);
         }
     }
     

--- a/src/main/java/com/example/petner/global/util/SessionUtils.java
+++ b/src/main/java/com/example/petner/global/util/SessionUtils.java
@@ -1,0 +1,147 @@
+package com.example.petner.global.util;
+
+import com.example.petner.domain.member.entity.Member;
+import com.example.petner.domain.member.service.MemberService;
+import com.example.petner.global.dto.SessionUser;
+import com.example.petner.global.exception.ErrorCode;
+import com.example.petner.global.exception.customException.MemberException;
+import jakarta.servlet.http.HttpSession;
+
+import java.util.Optional;
+
+public final class SessionUtils {
+    
+    private static final String SESSION_MEMBER_KEY = "member";
+    private static final String SESSION_USER_KEY = "sessionUser";
+    
+    private SessionUtils() {
+        // 유틸리티 클래스 - 인스턴스 생성 방지
+    }
+    
+    /**
+     * 현재 로그인한 사용자 ID 조회
+     * @param session HTTP 세션
+     * @return 사용자 ID (미인증 시 null)
+     */
+    public static Long getCurrentMemberId(HttpSession session) {
+        if (session == null) {
+            return null;
+        }
+        return (Long) session.getAttribute(SESSION_MEMBER_KEY);
+    }
+    
+    /**
+     * 현재 로그인한 사용자 정보 조회 (캐싱된 정보)
+     * @param session HTTP 세션
+     * @return SessionUser (미인증 시 empty)
+     */
+    public static Optional<SessionUser> getCurrentUser(HttpSession session) {
+        if (session == null) {
+            return Optional.empty();
+        }
+        SessionUser sessionUser = (SessionUser) session.getAttribute(SESSION_USER_KEY);
+        return Optional.ofNullable(sessionUser);
+    }
+    
+    /**
+     * 인증 상태 확인
+     * @param session HTTP 세션
+     * @return 인증 여부
+     */
+    public static boolean isAuthenticated(HttpSession session) {
+        return getCurrentMemberId(session) != null;
+    }
+    
+    /**
+     * 인증 필수 확인 (인증되지 않은 경우 예외 발생)
+     * @param session HTTP 세션
+     * @throws MemberException 미인증 시 UNAUTHORIZED_ACCESS
+     */
+    public static void requireAuthentication(HttpSession session) {
+        if (!isAuthenticated(session)) {
+            throw new MemberException(ErrorCode.UNAUTHORIZED_ACCESS);
+        }
+    }
+    
+    /**
+     * 현재 로그인한 사용자 ID 조회 (인증 필수)
+     * @param session HTTP 세션
+     * @return 사용자 ID
+     * @throws MemberException 미인증 시 UNAUTHORIZED_ACCESS
+     */
+    public static Long requireCurrentMemberId(HttpSession session) {
+        requireAuthentication(session);
+        return getCurrentMemberId(session);
+    }
+    
+    /**
+     * 현재 로그인한 사용자 정보 조회 (인증 필수)
+     * @param session HTTP 세션
+     * @return SessionUser
+     * @throws MemberException 미인증 시 UNAUTHORIZED_ACCESS
+     */
+    public static SessionUser requireCurrentUser(HttpSession session) {
+        requireAuthentication(session);
+        return getCurrentUser(session)
+                .orElseThrow(() -> new MemberException(ErrorCode.UNAUTHORIZED_ACCESS));
+    }
+    
+    /**
+     * 로그인 처리 - 세션에 사용자 정보 저장
+     * @param session HTTP 세션
+     * @param member 로그인한 사용자
+     */
+    public static void setSessionUser(HttpSession session, Member member) {
+        if (session == null || member == null) {
+            return;
+        }
+        
+        session.setAttribute(SESSION_MEMBER_KEY, member.getMemberId());
+        session.setAttribute(SESSION_USER_KEY, SessionUser.from(member));
+    }
+    
+    /**
+     * 세션 사용자 정보 갱신 (프로필 수정 시 사용)
+     * @param session HTTP 세션
+     * @param memberService 멤버 서비스
+     */
+    public static void refreshSessionUser(HttpSession session, MemberService memberService) {
+        Long memberId = getCurrentMemberId(session);
+        if (memberId != null) {
+            Member member = memberService.findById(memberId);
+            session.setAttribute(SESSION_USER_KEY, SessionUser.from(member));
+        }
+    }
+    
+    /**
+     * 로그아웃 처리 - 세션 무효화
+     * @param session HTTP 세션
+     */
+    public static void clearSession(HttpSession session) {
+        if (session != null) {
+            session.invalidate();
+        }
+    }
+    
+    // === 하위 호환성을 위한 메서드 (기존 방식) ===
+    
+    /**
+     * 세션에 사용자 ID만 저장 (기존 방식 호환)
+     * @param session HTTP 세션
+     * @param memberId 사용자 ID
+     */
+    public static void setMemberId(HttpSession session, Long memberId) {
+        if (session != null && memberId != null) {
+            session.setAttribute(SESSION_MEMBER_KEY, memberId);
+        }
+    }
+    
+    /**
+     * 세션에서 사용자 ID 조회 (기존 방식 호환)
+     * @param session HTTP 세션
+     * @return 사용자 ID
+     */
+    public static Optional<Long> getMemberId(HttpSession session) {
+        return Optional.ofNullable(getCurrentMemberId(session));
+    }
+}


### PR DESCRIPTION
# 요약
# 세션 기반 인증 시스템 구현 가이드

## 📋 개요

PETNER 프로젝트에 Redis 기반 세션 인증 시스템과 **@SessionMember ArgumentResolver**를 구현했습니다. 컨트롤러에서 `@SessionMember` 애노테이션을 사용하여 현재 로그인 사용자 정보를 자동으로 주입받을 수 있습니다.

## 🏗️ 구현한 기능

### 1. SessionUser DTO
**위치**: `src/main/java/com/example/petner/global/dto/SessionUser.java`

Redis 세션에 저장되는 사용자 정보 캐싱용 DTO입니다.

```java
public class SessionUser {
    private final Long memberId;
    private final String nickname;
    private final String email;
    private final Gender gender;
    private final HousingType housingType;
    private final String contact;
    private final Long locationId;
    private final String state;
    private final String district;
    private final boolean profileCompleted;
    
    // 편의 메서드
    public String getLocationName() // "서울특별시 강남구"
}
```

### 2. @SessionMember 애노테이션
**위치**: `src/main/java/com/example/petner/global/annotation/SessionMember.java`

컨트롤러 파라미터에 현재 로그인 사용자를 자동으로 주입하는 애노테이션입니다.

**사용법:**
```java
@SessionMember                    // 인증 필수 (기본값)
@SessionMember(required = false)  // 인증 선택적
```

### 3. SessionMemberArgumentResolver
**위치**: `src/main/java/com/example/petner/global/resolver/SessionMemberArgumentResolver.java`

@SessionMember 애노테이션이 붙은 파라미터에 SessionUser를 자동 주입하는 ArgumentResolver입니다.

### 4. SessionUtils 유틸리티 (내부 사용)
**위치**: `src/main/java/com/example/petner/global/util/SessionUtils.java`

ArgumentResolver에서 내부적으로 사용하는 세션 관리 유틸리티입니다. 직접 사용하지 말고 @SessionMember를 사용하세요.

### 5. AuthController 개선
**위치**: `src/main/java/com/example/petner/domain/auth/controller/AuthController.java`

@SessionMember를 사용하여 더 간결하고 명확한 코드로 개선했습니다.

**개선 사항:**
- `getCurrentMember()`: @SessionMember로 자동 주입, DB 조회 없음
- `checkAuthentication()`: @SessionMember(required = false)로 선택적 인증
- 코드 간소화 및 가독성 향상

### 6. Swagger 설정 변경
**위치**: `src/main/java/com/example/petner/global/config/Swagger/SwaggerConfig.java`

JWT 기반에서 세션 쿠키 기반 인증으로 변경하고, @SessionMember 파라미터를 스웨거에서 숨기도록 설정했습니다.

```java
// 세션 쿠키 방식 인증
.addSecuritySchemes("SESSION", new SecurityScheme()
    .type(SecurityScheme.Type.APIKEY)
    .in(SecurityScheme.In.COOKIE))

// @SessionMember 파라미터 숨기기
@Bean
public OperationCustomizer operationCustomizer() {
    return (operation, handlerMethod) -> {
        Parameter[] parameters = handlerMethod.getMethod().getParameters();
        for (int i = 0; i < parameters.length; i++) {
            if (parameters[i].isAnnotationPresent(SessionMember.class)) {
                if (operation.getParameters() != null && i < operation.getParameters().size()) {
                    operation.getParameters().remove(i);
                }
            }
        }
        return operation;
    };
}
```

## 🚀 Swagger 테스트 방법

### 1. 로그인
브라우저에서 다음 URL로 카카오 로그인:
```
http://localhost:8080/api/v1/auth/kakao/login
```

### 2. Swagger에서 테스트
로그인 완료 후 Swagger UI에서 세션 기반 API 테스트:
```
http://localhost:8080/swagger-ui.html
```

**테스트 가능한 API:**
- `GET /api/v1/auth/session` - 세션 상태 확인
- `GET /api/v1/auth/member` - 캐싱된 사용자 정보 조회
- `POST /api/v1/auth/logout` - 로그아웃

### 3. 응답 예시

**초기 카카오 로그인 후 (프로필 미완성 상태):**
```json
{
  "memberId": 4,
  "email": null,
  "nickname": null,
  "gender": null,
  "housingType": null,
  "contact": null,
  "locationId": null,
  "state": null,
  "district": null,
  "locationName": null,
  "profileCompleted": false
}
```

**프로필 완성 후:**
```json
{
  "memberId": 4,
  "email": "user@example.com",
  "nickname": "김철수", 
  "gender": "MALE",
  "housingType": "APARTMENT",
  "contact": "010-1234-5678",
  "locationId": 1,
  "state": "서울특별시",
  "district": "강남구", 
  "locationName": "서울특별시 강남구",
  "profileCompleted": true
}
```

## 💻 개발자를 위한 세션 활용 가이드

### 1. @SessionMember 기본 사용법

**인증 필수 API (가장 일반적):**
```java
@RestController
public class MyController {
    
    @GetMapping("/my-profile")
    public ResponseEntity<?> getMyProfile(@SessionMember SessionUser user) {
        // user 파라미터에 자동으로 현재 로그인 사용자 주입!
        // 인증되지 않은 경우 자동으로 401 에러 발생
        return ResponseEntity.ok(MyProfileResponse.builder()
            .memberId(user.getMemberId())
            .nickname(user.getNickname())
            .email(user.getEmail())
            .locationName(user.getLocationName())
            .build());
    }
}
```

**인증 선택적 API:**
```java
@GetMapping("/public-content")
public ResponseEntity<?> getPublicContent(@SessionMember(required = false) SessionUser user) {
    if (user != null) {
        // 로그인 사용자용 개인화된 콘텐츠
        return ResponseEntity.ok("안녕하세요 " + user.getNickname() + "님!");
    } else {
        // 게스트 사용자용 일반 콘텐츠  
        return ResponseEntity.ok("게스트로 이용 중입니다.");
    }
}
```

### 2. 실제 사용 예시

**채팅 메시지 전송:**
```java
@PostMapping("/chat/rooms/{roomId}/messages")
public ResponseEntity<?> sendMessage(
    @PathVariable Long roomId,
    @RequestBody ChatMessageRequest request,
    @SessionMember SessionUser user) {
    
    // 세션에서 자동으로 발신자 정보 주입
    ChatMessage message = chatService.sendMessage(roomId, user.getMemberId(), request);
    return ResponseEntity.ok(message);
}
```

**게시글 작성:**
```java
@PostMapping("/posts")
public ResponseEntity<?> createPost(
    @RequestBody PostCreateRequest request,
    @SessionMember SessionUser user) {
    
    // 작성자 정보를 세션에서 자동으로 가져옴
    Post post = postService.createPost(request, user.getMemberId());
    return ResponseEntity.ok(post);
}
```

### 3. 프로필 수정 시 세션 갱신

프로필 정보 수정 후에는 반드시 세션을 갱신해야 합니다:

```java
@PostMapping("/profile/update")
public ResponseEntity<?> updateProfile(
    @RequestBody UpdateRequest request, 
    @SessionMember SessionUser user,
    HttpSession session) {
    
    // 프로필 수정
    memberService.updateProfile(user.getMemberId(), request);
    
    // 세션 정보 갱신 (필수!)
    SessionUtils.refreshSessionUser(session, memberService);
    
    return ResponseEntity.ok("프로필이 업데이트되었습니다.");
}
```

## 🔧 기술적 세부사항

### 예외처리 시스템 통합
**새로 추가된 ErrorCode:**
```java
// 세션 관련 에러
SESSION_DATA_CORRUPTED("500-AU05", "세션 데이터가 손상되었습니다.", HttpStatus.INTERNAL_SERVER_ERROR)
SESSION_INVALID_DATA("400-AU06", "세션 데이터 형식이 올바르지 않습니다.", HttpStatus.BAD_REQUEST)
```

**예외처리 특징:**
- 세션 데이터 타입 불일치 시 자동 감지 및 적절한 에러 코드 반환
- Member 필수 필드 검증 (memberId만 필수, 나머지는 nullable)
- GlobalExceptionHandler와 완전히 통합되어 일관된 에러 응답 제공

### Redis 세션 저장 구조
```
session:SPRING_SESSION_12345ABCD = {
  "member": 123,           // Long memberId (기존 호환성)
  "sessionUser": {         // SessionUser 객체 (새로 추가)
    "memberId": 123,
    "nickname": "김철수",
    "email": "user@example.com",
    "gender": "MALE",
    "housingType": "APARTMENT",
    "contact": "010-1234-5678",
    "locationId": 1,
    "state": "서울특별시",
    "district": "강남구",
    "profileCompleted": true
  }
}
```

### 성능 최적화
- **세션 캐싱**: 자주 사용하는 사용자 정보를 Redis에 캐싱
- **DB 조회 최소화**: @SessionMember 사용 시 추가 DB 조회 없음
- **자동 인증 처리**: 401 에러 자동 처리로 보일러플레이트 코드 제거
- **Null 필드 허용**: 초기 로그인 시 null 필드를 허용하여 유연한 데이터 처리

### ArgumentResolver 동작 원리
1. `@SessionMember` 애노테이션 감지
2. HttpSession에서 SessionUser 정보 조회
3. `required=true`면 인증 필수, `required=false`면 선택적
4. SessionUser 객체를 컨트롤러 파라미터에 자동 주입

## 🎯 다음 단계

1. **다른 도메인 적용**: 채팅, 게시판 등에서 `@SessionMember` 활용
2. **프로필 수정 API**: `SessionUtils.refreshSessionUser()` 호출 추가  
3. **성능 모니터링**: 세션 캐싱 효과 측정 및 최적화

## ⚠️ 주의사항

1. **올바른 애노테이션 사용**:
   ```java
   // ✅ 올바른 사용
   public ResponseEntity<?> api(@SessionMember SessionUser user) { ... }
   
   // ❌ 잘못된 사용 - SessionUser 타입이 아님
   public ResponseEntity<?> api(@SessionMember Long memberId) { ... }
   ```

2. **프로필 수정 후 세션 갱신 필수**: 
   ```java
   SessionUtils.refreshSessionUser(session, memberService);
   ```

3. **인증 선택적 처리**:
   ```java
   // required=false 사용 시 null 체크 필수
   public ResponseEntity<?> api(@SessionMember(required = false) SessionUser user) {
       if (user == null) {
           // 게스트 사용자 처리
       }
   }
   ```

4. **초기 로그인 시 Null 필드 처리**:
   ```java
   // 초기 카카오 로그인 시 많은 필드가 null일 수 있음
   if (user.getEmail() != null) {
       // 이메일이 설정된 경우만 처리
   }
   ```

5. **환경별 세션 저장소**:
   - **개발/운영**: Redis 서버 (이미 설정됨)
   - **테스트**: 메모리 기반 (`spring.session.store-type=none`)

6. **스웨거 UI 사용법**:
   - `@SessionMember` 파라미터는 자동으로 숨겨짐
   - "No parameters"로 표시되는 것이 정상
   - 세션 쿠키는 브라우저에서 자동으로 전송됨



# 연관 이슈 및 Close 할 이슈 작성
(fix #일이삼)
<!--이슈 번호를 적어주세요(예시: fix #123). -->

-- PR 시 다음과 같이 작성
#31 

close #31 

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?