### PR TITLE
[Feature] Post API에 세션 기반 사용자 인증 연동 - feature/ddd-32

### DIFF
--- a/src/main/java/com/example/petner/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/petner/domain/post/controller/PostController.java
@@ -7,6 +7,8 @@ import com.example.petner.domain.post.dto.response.PostSummaryResponse;
 import com.example.petner.domain.post.service.PostService;
 import com.example.petner.search.document.PostDocument;
 import com.example.petner.search.service.PostSearchService;
+import com.example.petner.global.annotation.SessionMember;
+import com.example.petner.global.dto.SessionUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -36,10 +38,8 @@ public class PostController {
     @PostMapping
     @Operation(summary = "게시물 생성", description = "새로운 게시물을 생성합니다.")
     @ApiResponse(responseCode = "201", description = "게시물 생성 성공")
-    public ResponseEntity<PostResponse> createPost(@Valid @RequestBody PostCreateRequest request) {
-        // TODO: 추후 인증 기능이 구현되면, 현재 로그인한 사용자의 ID를 가져와서 사용해야 합니다.
-        Long currentMemberId = 1L;
-        PostResponse response = postService.createPost(currentMemberId, request);
+    public ResponseEntity<PostResponse> createPost(@Valid @RequestBody PostCreateRequest request, @SessionMember SessionUser user) {
+        PostResponse response = postService.createPost(user.getMemberId(), request);
 
         URI location = ServletUriComponentsBuilder
                 .fromCurrentRequest()
@@ -78,18 +78,16 @@ public class PostController {
     @PatchMapping("/{postId}")
     @Operation(summary = "게시물 수정", description = "특정 게시물을 수정합니다.")
     @ApiResponse(responseCode = "200", description = "게시물 수정 성공")
-    public ResponseEntity<PostResponse> updatePost(@PathVariable Long postId, @Valid @RequestBody PostUpdateRequest request) {
-        // TODO: 추후 인증 기능이 구현되면, 게시물 작성자와 현재 로그인한 사용자가 동일한지 확인해야 합니다.
-        PostResponse response = postService.updatePost(postId, request);
+    public ResponseEntity<PostResponse> updatePost(@PathVariable Long postId, @Valid @RequestBody PostUpdateRequest request, @SessionMember SessionUser user) {
+        PostResponse response = postService.updatePost(postId, request, user.getMemberId());
         return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/{postId}")
     @Operation(summary = "게시물 삭제", description = "특정 게시물을 삭제합니다.")
     @ApiResponse(responseCode = "200", description = "게시물 삭제 성공")
-    public ResponseEntity<String> deletePost(@PathVariable Long postId) {
-        // TODO: 추후 인증 기능이 구현되면, 게시물 작성자와 현재 로그인한 사용자가 동일한지 확인해야 합니다.
-        postService.deletePost(postId);
+    public ResponseEntity<String> deletePost(@PathVariable Long postId, @SessionMember SessionUser user) {
+        postService.deletePost(postId, user.getMemberId());
         return ResponseEntity.ok("게시물이 성공적으로 삭제되었습니다.");
     }
 

--- a/src/main/java/com/example/petner/domain/post/service/PostService.java
+++ b/src/main/java/com/example/petner/domain/post/service/PostService.java
@@ -67,6 +67,9 @@ public class PostService {
 
     @Transactional
     public PostResponse updatePost(Long postId, PostUpdateRequest request, Long currentUserId) {
+        memberRepository.findById(currentUserId)
+                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
 
@@ -85,6 +88,9 @@ public class PostService {
 
     @Transactional
     public void deletePost(Long postId, Long currentUserId) {
+        memberRepository.findById(currentUserId)
+                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
 

--- a/src/main/java/com/example/petner/domain/post/service/PostService.java
+++ b/src/main/java/com/example/petner/domain/post/service/PostService.java
@@ -66,11 +66,14 @@ public class PostService {
     }
 
     @Transactional
-    public PostResponse updatePost(Long postId, PostUpdateRequest request) {
+    public PostResponse updatePost(Long postId, PostUpdateRequest request, Long currentUserId) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
 
-        // TODO: Implement author check for update permission
+        // 작성자 권한 확인
+        if (!post.getAuthor().getMemberId().equals(currentUserId)) {
+            throw new PostException(ErrorCode.POST_ACCESS_DENIED);
+        }
 
         post.update(request.getTitle(), request.getContent(), request.getThumbImageUrl());
 
@@ -81,11 +84,14 @@ public class PostService {
     }
 
     @Transactional
-    public void deletePost(Long postId) {
+    public void deletePost(Long postId, Long currentUserId) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
 
-        // TODO: Implement author check for delete permission
+        // 작성자 권한 확인
+        if (!post.getAuthor().getMemberId().equals(currentUserId)) {
+            throw new PostException(ErrorCode.POST_ACCESS_DENIED);
+        }
 
         postRepository.delete(post);
 


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
- Redis 세션 연동 및 사용자 인증 기반 게시물 CUD 기능 구현

기존 `PostController`에 하드코딩되어 있던 사용자 ID(`currentMemberId = 1L`)를 제거했습니다. Redis 기반의 세션 정보를 활용하여, 실제로 로그인한 사용자의 ID를 기준으로 게시물을 생성, 수정, 삭제하도록 로직을 개선했습니다.

또한, 게시물 수정 및 삭제 시 현재 로그인한 사용자와 게시물 작성자가 일치하는지 확인하는 소유권 검증 로직을 추가하여 API의 안정성을 높였습니다.

# 연관 이슈 및 Close 할 이슈 작성
<!--이슈 번호를 적어주세요(예시: fix #123). -->
#32

close #32

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?