### PR TITLE
[Feature] Comment API에 세션 기반 사용자 인증 연동 - feature/ddd-37

### DIFF
--- a/src/main/java/com/example/petner/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/example/petner/domain/comment/controller/CommentController.java
@@ -4,6 +4,8 @@ import com.example.petner.domain.comment.dto.request.CommentCreateRequest;
 import com.example.petner.domain.comment.dto.request.CommentUpdateRequest;
 import com.example.petner.domain.comment.dto.response.CommentResponse;
 import com.example.petner.domain.comment.service.CommentService;
+import com.example.petner.global.annotation.SessionMember;
+import com.example.petner.global.dto.SessionUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -28,12 +30,10 @@ public class CommentController {
     @ApiResponse(responseCode = "201", description = "댓글 생성 성공")
     public ResponseEntity<CommentResponse> createComment(
             @Parameter(description = "게시물 ID") @PathVariable Long postId,
-            @Valid @RequestBody CommentCreateRequest request) {
+            @Valid @RequestBody CommentCreateRequest request,
+            @SessionMember SessionUser user) {
 
-        // TODO: 추후 인증 기능이 구현되면, 현재 로그인한 사용자의 ID를 가져와서 사용해야 합니다.
-        Long currentMemberId = 1L;
-        CommentResponse response = commentService.createComment(postId, currentMemberId, request);
-
+        CommentResponse response = commentService.createComment(postId, user.getMemberId(), request);
         return ResponseEntity.created(null).body(response);
     }
 
@@ -52,10 +52,10 @@ public class CommentController {
     @ApiResponse(responseCode = "200", description = "댓글 수정 성공")
     public ResponseEntity<CommentResponse> updateComment(
             @Parameter(description = "댓글 ID") @PathVariable Long commentId,
-            @Valid @RequestBody CommentUpdateRequest request) {
+            @Valid @RequestBody CommentUpdateRequest request,
+            @SessionMember SessionUser user) {
 
-        // TODO: 추후 인증 기능이 구현되면, 댓글 작성자와 현재 로그인한 사용자가 동일한지 확인해야 합니다.
-        CommentResponse response = commentService.updateComment(commentId, request);
+        CommentResponse response = commentService.updateComment(commentId, user.getMemberId(), request);
         return ResponseEntity.ok(response);
     }
 
@@ -63,10 +63,10 @@ public class CommentController {
     @Operation(summary = "댓글 삭제", description = "특정 댓글을 삭제합니다.")
     @ApiResponse(responseCode = "200", description = "댓글 삭제 성공")
     public ResponseEntity<String> deleteComment(
-            @Parameter(description = "댓글 ID") @PathVariable Long commentId) {
+            @Parameter(description = "댓글 ID") @PathVariable Long commentId,
+            @SessionMember SessionUser user) {
 
-        // TODO: 추후 인증 기능이 구현되면, 댓글 작성자와 현재 로그인한 사용자가 동일한지 확인해야 합니다.
-        commentService.deleteComment(commentId);
+        commentService.deleteComment(commentId, user.getMemberId());
         return ResponseEntity.ok("댓글이 성공적으로 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/example/petner/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/petner/domain/comment/service/CommentService.java
@@ -84,10 +84,6 @@ public class CommentService {
 
     @Transactional
     public CommentResponse updateComment(Long commentId, Long currentUserId, CommentUpdateRequest request) {
-        // 현재 사용자가 존재하는지 확인
-        memberRepository.findById(currentUserId)
-                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
-
         Comment comment = commentRepository.findByIdWithMember(commentId)
                 .orElseThrow(() -> new CommentException(ErrorCode.COMMENT_NOT_FOUND));
 
@@ -103,10 +99,6 @@ public class CommentService {
 
     @Transactional
     public void deleteComment(Long commentId, Long currentUserId) {
-        // 현재 사용자가 존재하는지 확인
-        memberRepository.findById(currentUserId)
-                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
-
         Comment comment = commentRepository.findByIdWithMember(commentId)
                 .orElseThrow(() -> new CommentException(ErrorCode.COMMENT_NOT_FOUND));
 

--- a/src/main/java/com/example/petner/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/petner/domain/comment/service/CommentService.java
@@ -31,11 +31,11 @@ public class CommentService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public CommentResponse createComment(Long postId, Long authorId, CommentCreateRequest request) {
+    public CommentResponse createComment(Long postId, Long currentUserId, CommentCreateRequest request) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
 
-        Member author = memberRepository.findById(authorId)
+        Member author = memberRepository.findById(currentUserId)
                 .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
 
         Comment parentComment = null;

--- a/src/main/java/com/example/petner/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/petner/domain/comment/service/CommentService.java
@@ -83,9 +83,18 @@ public class CommentService {
     }
 
     @Transactional
-    public CommentResponse updateComment(Long commentId, CommentUpdateRequest request) {
+    public CommentResponse updateComment(Long commentId, Long currentUserId, CommentUpdateRequest request) {
+        // 현재 사용자가 존재하는지 확인
+        memberRepository.findById(currentUserId)
+                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+
         Comment comment = commentRepository.findByIdWithMember(commentId)
                 .orElseThrow(() -> new CommentException(ErrorCode.COMMENT_NOT_FOUND));
+
+        // 댓글 작성자와 수정 요청자가 동일한지 확인
+        if (!comment.getMember().getMemberId().equals(currentUserId)) {
+            throw new CommentException(ErrorCode.COMMENT_ACCESS_DENIED);
+        }
 
         comment.update(request.getContent());
 
@@ -93,9 +102,18 @@ public class CommentService {
     }
 
     @Transactional
-    public void deleteComment(Long commentId) {
-        Comment comment = commentRepository.findById(commentId)
+    public void deleteComment(Long commentId, Long currentUserId) {
+        // 현재 사용자가 존재하는지 확인
+        memberRepository.findById(currentUserId)
+                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+
+        Comment comment = commentRepository.findByIdWithMember(commentId)
                 .orElseThrow(() -> new CommentException(ErrorCode.COMMENT_NOT_FOUND));
+
+        // 댓글 작성자와 삭제 요청자가 동일한지 확인
+        if (!comment.getMember().getMemberId().equals(currentUserId)) {
+            throw new CommentException(ErrorCode.COMMENT_ACCESS_DENIED);
+        }
 
         commentRepository.delete(comment);
     }

--- a/src/main/java/com/example/petner/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/petner/global/exception/GlobalExceptionHandler.java
@@ -31,11 +31,11 @@ import java.util.Map;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler({
-            MemberException.class, 
-            DogException.class, 
-            PostException.class, 
-            ChatException.class, 
-            ShelterException.class
+            MemberException.class,
+            DogException.class,
+            PostException.class,
+            ChatException.class,
+            CommentException.class
     })
     public ResponseEntity<ErrorPayload> handleCustomException(RuntimeException ex, HttpServletRequest request) {
         ErrorCode errorCode = extractErrorCode(ex);


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
기존 `CommentController`에 하드코딩되어 있던 사용자 ID(`currentMemberId = 1L`)를 제거하고, Redis 기반 세션 정보를 활용하여 실제 로그인한 사용자를 기준으로 댓글을 생성, 수정, 삭제하도록 로직을 개선했습니다.

또한, 댓글 수정 및 삭제 시 현재 로그인한 사용자와 댓글 작성자가 일치하는지 확인하는 소유권 검증 로직을 추가하여 API의 안정성을 높였습니다. 더불어 `createComment` 메서드의 매개변수명을 더 명확하게 개선하고, `CommentException`에 대한 전역 예외 처리도 추가했습니다.

# 연관 이슈 및 Close 할 이슈 작성
<!--이슈 번호를 적어주세요(예시: fix #123). -->
#37

close #37

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?