### PR TITLE
[Refactor] Post/Comment DTO 네이밍 컨벤션 통일 및 성능 개선 - feature/ddd-34

### DIFF
--- a/src/main/java/com/example/petner/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/example/petner/domain/comment/controller/CommentController.java
@@ -1,8 +1,9 @@
 package com.example.petner.domain.comment.controller;
 
-import com.example.petner.domain.comment.dto.request.CommentCreateRequest;
-import com.example.petner.domain.comment.dto.request.CommentUpdateRequest;
-import com.example.petner.domain.comment.dto.response.CommentResponse;
+import com.example.petner.domain.comment.dto.request.CommentCreateRequestDto;
+import com.example.petner.domain.comment.dto.request.CommentUpdateRequestDto;
+import com.example.petner.domain.comment.dto.response.CommentResponseDto;
+import com.example.petner.domain.comment.dto.response.CommentDeleteResponseDto;
 import com.example.petner.domain.comment.service.CommentService;
 import com.example.petner.global.annotation.SessionMember;
 import com.example.petner.global.dto.SessionUser;
@@ -28,45 +29,45 @@ public class CommentController {
     @PostMapping("/posts/{postId}/comments")
     @Operation(summary = "댓글/대댓글 생성", description = "특정 게시물에 댓글 또는 대댓글을 생성합니다.")
     @ApiResponse(responseCode = "201", description = "댓글 생성 성공")
-    public ResponseEntity<CommentResponse> createComment(
+    public ResponseEntity<CommentResponseDto> createComment(
             @Parameter(description = "게시물 ID") @PathVariable Long postId,
-            @Valid @RequestBody CommentCreateRequest request,
+            @Valid @RequestBody CommentCreateRequestDto request,
             @SessionMember SessionUser user) {
 
-        CommentResponse response = commentService.createComment(postId, user.getMemberId(), request);
+        CommentResponseDto response = commentService.createComment(postId, user.getMemberId(), request);
         return ResponseEntity.created(null).body(response);
     }
 
     @GetMapping("/posts/{postId}/comments")
     @Operation(summary = "게시물 댓글 전체 조회", description = "특정 게시물의 모든 댓글을 계층 구조로 조회합니다.")
     @ApiResponse(responseCode = "200", description = "댓글 목록 조회 성공")
-    public ResponseEntity<List<CommentResponse>> getCommentsByPost(
+    public ResponseEntity<List<CommentResponseDto>> getCommentsByPost(
             @Parameter(description = "게시물 ID") @PathVariable Long postId) {
 
-        List<CommentResponse> response = commentService.getCommentsByPost(postId);
+        List<CommentResponseDto> response = commentService.getCommentsByPost(postId);
         return ResponseEntity.ok(response);
     }
 
     @PatchMapping("/comments/{commentId}")
     @Operation(summary = "댓글 수정", description = "특정 댓글을 수정합니다.")
     @ApiResponse(responseCode = "200", description = "댓글 수정 성공")
-    public ResponseEntity<CommentResponse> updateComment(
+    public ResponseEntity<CommentResponseDto> updateComment(
             @Parameter(description = "댓글 ID") @PathVariable Long commentId,
-            @Valid @RequestBody CommentUpdateRequest request,
+            @Valid @RequestBody CommentUpdateRequestDto request,
             @SessionMember SessionUser user) {
 
-        CommentResponse response = commentService.updateComment(commentId, user.getMemberId(), request);
+        CommentResponseDto response = commentService.updateComment(commentId, user.getMemberId(), request);
         return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/comments/{commentId}")
     @Operation(summary = "댓글 삭제", description = "특정 댓글을 삭제합니다.")
     @ApiResponse(responseCode = "200", description = "댓글 삭제 성공")
-    public ResponseEntity<String> deleteComment(
+    public ResponseEntity<CommentDeleteResponseDto> deleteComment(
             @Parameter(description = "댓글 ID") @PathVariable Long commentId,
             @SessionMember SessionUser user) {
 
-        commentService.deleteComment(commentId, user.getMemberId());
-        return ResponseEntity.ok("댓글이 성공적으로 삭제되었습니다.");
+        CommentDeleteResponseDto response = commentService.deleteComment(commentId, user.getMemberId());
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/petner/domain/comment/dto/request/CommentCreateRequestDto.java
+++ b/src/main/java/com/example/petner/domain/comment/dto/request/CommentCreateRequestDto.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Schema(description = "댓글 생성 요청")
-public class CommentCreateRequest {
+public class CommentCreateRequestDto {
 
     @Schema(description = "댓글 내용", example = "좋은 게시물이네요!")
     @NotBlank(message = "댓글 내용은 비워둘 수 없습니다.")

--- a/src/main/java/com/example/petner/domain/comment/dto/request/CommentUpdateRequestDto.java
+++ b/src/main/java/com/example/petner/domain/comment/dto/request/CommentUpdateRequestDto.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Schema(description = "댓글 수정 요청")
-public class CommentUpdateRequest {
+public class CommentUpdateRequestDto {
 
     @Schema(description = "댓글 내용", example = "수정된 댓글 내용입니다.")
     @NotBlank(message = "댓글 내용은 비워둘 수 없습니다.")

--- a/src/main/java/com/example/petner/domain/comment/dto/response/CommentDeleteResponseDto.java
+++ b/src/main/java/com/example/petner/domain/comment/dto/response/CommentDeleteResponseDto.java
@@ -1,0 +1,61 @@
+package com.example.petner.domain.comment.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 댓글 삭제 성공 응답을 위한 DTO 클래스
+ *
+ * 서버에서 클라이언트로 댓글 삭제 성공 메시지를 전달할 때 사용하는 데이터 전송 객체입니다.
+ * 댓글 삭제 API의 응답으로 사용됩니다.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentDeleteResponseDto {
+
+    /**
+     * 삭제된 댓글 고유 ID
+     */
+    private Long commentId;
+
+    /**
+     * 삭제를 수행한 멤버 고유 ID
+     */
+    private Long memberId;
+
+    /**
+     * 성공 메시지
+     */
+    private String message;
+
+    /**
+     * 삭제 성공 상태
+     */
+    private boolean success;
+
+    /**
+     * 댓글 삭제 성공 응답 DTO 생성자
+     *
+     * @param commentId 삭제된 댓글 고유 ID
+     * @param memberId 삭제를 수행한 멤버 고유 ID
+     * @param message 성공 메시지
+     */
+    public CommentDeleteResponseDto(Long commentId, Long memberId, String message) {
+        this.commentId = commentId;
+        this.memberId = memberId;
+        this.message = message;
+        this.success = true;
+    }
+
+    /**
+     * 댓글 삭제 성공 응답 생성
+     *
+     * @param commentId 삭제된 댓글 고유 ID
+     * @param memberId 삭제를 수행한 멤버 고유 ID
+     * @return CommentDeleteResponseDto
+     */
+    public static CommentDeleteResponseDto success(Long commentId, Long memberId) {
+        return new CommentDeleteResponseDto(commentId, memberId, "댓글이 성공적으로 삭제되었습니다.");
+    }
+}

--- a/src/main/java/com/example/petner/domain/comment/dto/response/CommentResponseDto.java
+++ b/src/main/java/com/example/petner/domain/comment/dto/response/CommentResponseDto.java
@@ -7,7 +7,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
-public class CommentResponse {
+public class CommentResponseDto {
 
     private final Long commentId;
     private final String content;
@@ -16,9 +16,9 @@ public class CommentResponse {
     private final LocalDateTime updatedAt;
     private final Long parentCommentId;
     private final boolean isReply;
-    private List<CommentResponse> replies;
+    private List<CommentResponseDto> replies;
 
-    public CommentResponse(Comment comment) {
+    public CommentResponseDto(Comment comment) {
         this.commentId = comment.getCommentId();
         this.content = comment.getContent();
         this.authorNickname = comment.getMember().getNickname();
@@ -29,7 +29,7 @@ public class CommentResponse {
         this.replies = List.of();
     }
 
-    public void setReplies(List<CommentResponse> replies) {
+    public void setReplies(List<CommentResponseDto> replies) {
         this.replies = replies;
     }
 }

--- a/src/main/java/com/example/petner/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/petner/domain/comment/service/CommentService.java
@@ -1,8 +1,9 @@
 package com.example.petner.domain.comment.service;
 
-import com.example.petner.domain.comment.dto.request.CommentCreateRequest;
-import com.example.petner.domain.comment.dto.request.CommentUpdateRequest;
-import com.example.petner.domain.comment.dto.response.CommentResponse;
+import com.example.petner.domain.comment.dto.request.CommentCreateRequestDto;
+import com.example.petner.domain.comment.dto.request.CommentUpdateRequestDto;
+import com.example.petner.domain.comment.dto.response.CommentResponseDto;
+import com.example.petner.domain.comment.dto.response.CommentDeleteResponseDto;
 import com.example.petner.domain.comment.entity.Comment;
 import com.example.petner.domain.comment.repository.CommentRepository;
 import com.example.petner.domain.member.entity.Member;
@@ -31,7 +32,7 @@ public class CommentService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public CommentResponse createComment(Long postId, Long currentUserId, CommentCreateRequest request) {
+    public CommentResponseDto createComment(Long postId, Long currentUserId, CommentCreateRequestDto request) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
 
@@ -56,26 +57,26 @@ public class CommentService {
                 .build();
 
         Comment savedComment = commentRepository.save(comment);
-        return new CommentResponse(savedComment);
+        return new CommentResponseDto(savedComment);
     }
 
-    public List<CommentResponse> getCommentsByPost(Long postId) {
+    public List<CommentResponseDto> getCommentsByPost(Long postId) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
 
         List<Comment> allComments = commentRepository.findByPostOrderByCreatedAtAsc(post);
 
-        Map<Long, List<CommentResponse>> repliesMap = allComments.stream()
+        Map<Long, List<CommentResponseDto>> repliesMap = allComments.stream()
                 .filter(Comment::isReply)
                 .collect(Collectors.groupingBy(
                         comment -> comment.getParentComment().getCommentId(),
-                        Collectors.mapping(CommentResponse::new, Collectors.toList())
+                        Collectors.mapping(CommentResponseDto::new, Collectors.toList())
                 ));
 
         return allComments.stream()
                 .filter(comment -> !comment.isReply())
                 .map(comment -> {
-                    CommentResponse response = new CommentResponse(comment);
+                    CommentResponseDto response = new CommentResponseDto(comment);
                     response.setReplies(repliesMap.getOrDefault(comment.getCommentId(), List.of()));
                     return response;
                 })
@@ -83,7 +84,7 @@ public class CommentService {
     }
 
     @Transactional
-    public CommentResponse updateComment(Long commentId, Long currentUserId, CommentUpdateRequest request) {
+    public CommentResponseDto updateComment(Long commentId, Long currentUserId, CommentUpdateRequestDto request) {
         Comment comment = commentRepository.findByIdWithMember(commentId)
                 .orElseThrow(() -> new CommentException(ErrorCode.COMMENT_NOT_FOUND));
 
@@ -94,11 +95,11 @@ public class CommentService {
 
         comment.update(request.getContent());
 
-        return new CommentResponse(comment);
+        return new CommentResponseDto(comment);
     }
 
     @Transactional
-    public void deleteComment(Long commentId, Long currentUserId) {
+    public CommentDeleteResponseDto deleteComment(Long commentId, Long currentUserId) {
         Comment comment = commentRepository.findByIdWithMember(commentId)
                 .orElseThrow(() -> new CommentException(ErrorCode.COMMENT_NOT_FOUND));
 
@@ -108,5 +109,7 @@ public class CommentService {
         }
 
         commentRepository.delete(comment);
+
+        return CommentDeleteResponseDto.success(commentId, currentUserId);
     }
 }

--- a/src/main/java/com/example/petner/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/petner/domain/post/controller/PostController.java
@@ -1,9 +1,10 @@
 package com.example.petner.domain.post.controller;
 
-import com.example.petner.domain.post.dto.request.PostCreateRequest;
-import com.example.petner.domain.post.dto.request.PostUpdateRequest;
-import com.example.petner.domain.post.dto.response.PostResponse;
-import com.example.petner.domain.post.dto.response.PostSummaryResponse;
+import com.example.petner.domain.post.dto.request.PostCreateRequestDto;
+import com.example.petner.domain.post.dto.request.PostUpdateRequestDto;
+import com.example.petner.domain.post.dto.response.PostResponseDto;
+import com.example.petner.domain.post.dto.response.PostSummaryResponseDto;
+import com.example.petner.domain.post.dto.response.PostDeleteResponseDto;
 import com.example.petner.domain.post.service.PostService;
 import com.example.petner.search.document.PostDocument;
 import com.example.petner.search.service.PostSearchService;
@@ -38,8 +39,8 @@ public class PostController {
     @PostMapping
     @Operation(summary = "게시물 생성", description = "새로운 게시물을 생성합니다.")
     @ApiResponse(responseCode = "201", description = "게시물 생성 성공")
-    public ResponseEntity<PostResponse> createPost(@Valid @RequestBody PostCreateRequest request, @SessionMember SessionUser user) {
-        PostResponse response = postService.createPost(user.getMemberId(), request);
+    public ResponseEntity<PostResponseDto> createPost(@Valid @RequestBody PostCreateRequestDto request, @SessionMember SessionUser user) {
+        PostResponseDto response = postService.createPost(user.getMemberId(), request);
 
         URI location = ServletUriComponentsBuilder
                 .fromCurrentRequest()
@@ -53,15 +54,15 @@ public class PostController {
     @GetMapping("/{postId}")
     @Operation(summary = "게시물 상세 조회", description = "특정 게시물 하나를 상세 조회합니다.")
     @ApiResponse(responseCode = "200", description = "게시물 조회 성공")
-    public ResponseEntity<PostResponse> getPost(@PathVariable Long postId) {
-        PostResponse response = postService.getPost(postId);
+    public ResponseEntity<PostResponseDto> getPost(@PathVariable Long postId) {
+        PostResponseDto response = postService.getPost(postId);
         return ResponseEntity.ok(response);
     }
 
     @GetMapping
     @Operation(summary = "게시물 목록 조회", description = "전체 게시물 목록을 페이징하여 조회합니다.")
     @ApiResponse(responseCode = "200", description = "게시물 목록 조회 성공")
-    public ResponseEntity<Page<PostSummaryResponse>> getPosts(
+    public ResponseEntity<Page<PostSummaryResponseDto>> getPosts(
             @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "페이지 크기", example = "10") @RequestParam(defaultValue = "10") int size,
             @Parameter(description = "정렬 방식 (예: createdAt,desc)", example = "createdAt,desc") @RequestParam(defaultValue = "createdAt,desc") String sort) {
@@ -71,24 +72,24 @@ public class PostController {
             ? Sort.Direction.ASC : Sort.Direction.DESC;
 
         Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortParams[0]));
-        Page<PostSummaryResponse> response = postService.getPosts(pageable);
+        Page<PostSummaryResponseDto> response = postService.getPosts(pageable);
         return ResponseEntity.ok(response);
     }
 
     @PatchMapping("/{postId}")
     @Operation(summary = "게시물 수정", description = "특정 게시물을 수정합니다.")
     @ApiResponse(responseCode = "200", description = "게시물 수정 성공")
-    public ResponseEntity<PostResponse> updatePost(@PathVariable Long postId, @Valid @RequestBody PostUpdateRequest request, @SessionMember SessionUser user) {
-        PostResponse response = postService.updatePost(postId, request, user.getMemberId());
+    public ResponseEntity<PostResponseDto> updatePost(@PathVariable Long postId, @Valid @RequestBody PostUpdateRequestDto request, @SessionMember SessionUser user) {
+        PostResponseDto response = postService.updatePost(postId, request, user.getMemberId());
         return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/{postId}")
     @Operation(summary = "게시물 삭제", description = "특정 게시물을 삭제합니다.")
     @ApiResponse(responseCode = "200", description = "게시물 삭제 성공")
-    public ResponseEntity<String> deletePost(@PathVariable Long postId, @SessionMember SessionUser user) {
-        postService.deletePost(postId, user.getMemberId());
-        return ResponseEntity.ok("게시물이 성공적으로 삭제되었습니다.");
+    public ResponseEntity<PostDeleteResponseDto> deletePost(@PathVariable Long postId, @SessionMember SessionUser user) {
+        PostDeleteResponseDto response = postService.deletePost(postId, user.getMemberId());
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/search")

--- a/src/main/java/com/example/petner/domain/post/dto/request/PostCreateRequestDto.java
+++ b/src/main/java/com/example/petner/domain/post/dto/request/PostCreateRequestDto.java
@@ -11,19 +11,19 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Schema(description = "게시물 수정 요청")
-public class PostUpdateRequest {
+@Schema(description = "게시물 생성 요청")
+public class PostCreateRequestDto {
 
-    @Schema(description = "게시물 제목", example = "수정된 게시물", maxLength = 200)
+    @Schema(description = "게시물 제목", example = "첫 번째 게시물", maxLength = 200)
     @NotBlank(message = "게시물 제목은 비워둘 수 없습니다.")
     @Size(max = 200, message = "제목은 200자를 초과할 수 없습니다.")
     private String title;
 
-    @Schema(description = "게시물 내용", example = "수정된 내용입니다.")
+    @Schema(description = "게시물 내용", example = "안녕하세요! 첫 번째 게시물입니다.")
     @NotBlank(message = "게시물 내용은 비워둘 수 없습니다.")
     private String content;
 
-    @Schema(description = "썸네일 이미지 URL", example = "https://example.com/updated-image.jpg", maxLength = 500)
+    @Schema(description = "썸네일 이미지 URL", example = "https://example.com/image.jpg", maxLength = 500)
     @Size(max = 500, message = "썸네일 이미지 URL은 500자를 초과할 수 없습니다.")
     private String thumbImageUrl;
 }

--- a/src/main/java/com/example/petner/domain/post/dto/request/PostUpdateRequestDto.java
+++ b/src/main/java/com/example/petner/domain/post/dto/request/PostUpdateRequestDto.java
@@ -11,19 +11,19 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Schema(description = "게시물 생성 요청")
-public class PostCreateRequest {
+@Schema(description = "게시물 수정 요청")
+public class PostUpdateRequestDto {
 
-    @Schema(description = "게시물 제목", example = "첫 번째 게시물", maxLength = 200)
+    @Schema(description = "게시물 제목", example = "수정된 게시물", maxLength = 200)
     @NotBlank(message = "게시물 제목은 비워둘 수 없습니다.")
     @Size(max = 200, message = "제목은 200자를 초과할 수 없습니다.")
     private String title;
 
-    @Schema(description = "게시물 내용", example = "안녕하세요! 첫 번째 게시물입니다.")
+    @Schema(description = "게시물 내용", example = "수정된 내용입니다.")
     @NotBlank(message = "게시물 내용은 비워둘 수 없습니다.")
     private String content;
 
-    @Schema(description = "썸네일 이미지 URL", example = "https://example.com/image.jpg", maxLength = 500)
+    @Schema(description = "썸네일 이미지 URL", example = "https://example.com/updated-image.jpg", maxLength = 500)
     @Size(max = 500, message = "썸네일 이미지 URL은 500자를 초과할 수 없습니다.")
     private String thumbImageUrl;
 }

--- a/src/main/java/com/example/petner/domain/post/dto/response/PostDeleteResponseDto.java
+++ b/src/main/java/com/example/petner/domain/post/dto/response/PostDeleteResponseDto.java
@@ -1,0 +1,31 @@
+package com.example.petner.domain.post.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 게시글 삭제 성공 응답을 위한 DTO 클래스
+ *
+ * 서버에서 클라이언트로 게시글 삭제 성공 메시지를 전달할 때 사용하는 데이터 전송 객체입니다.
+ * 게시글 삭제 API의 응답으로 사용됩니다.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostDeleteResponseDto {
+    private Long postId;
+    private Long memberId;
+    private String message;
+    private boolean success;
+
+    public PostDeleteResponseDto(Long postId, Long memberId, String message) {
+        this.postId = postId;
+        this.memberId = memberId;
+        this.message = message;
+        this.success = true;
+    }
+
+    public static PostDeleteResponseDto success(Long postId, Long memberId) {
+        return new PostDeleteResponseDto(postId, memberId, "게시글이 성공적으로 삭제되었습니다.");
+    }
+}

--- a/src/main/java/com/example/petner/domain/post/dto/response/PostResponseDto.java
+++ b/src/main/java/com/example/petner/domain/post/dto/response/PostResponseDto.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import java.time.LocalDateTime;
 
 @Getter
-public class PostResponse {
+public class PostResponseDto {
 
     private final Long postId;
     private final String title;
@@ -17,7 +17,7 @@ public class PostResponse {
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
-    public PostResponse(Post post) {
+    public PostResponseDto(Post post) {
         this.postId = post.getPostId();
         this.title = post.getTitle();
         this.content = post.getContent();

--- a/src/main/java/com/example/petner/domain/post/dto/response/PostSummaryResponseDto.java
+++ b/src/main/java/com/example/petner/domain/post/dto/response/PostSummaryResponseDto.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import java.time.LocalDateTime;
 
 @Getter
-public class PostSummaryResponse {
+public class PostSummaryResponseDto {
 
     private final Long postId;
     private final String title;
@@ -15,7 +15,7 @@ public class PostSummaryResponse {
     private final int viewCount;
     private final LocalDateTime createdAt;
 
-    public PostSummaryResponse(Post post) {
+    public PostSummaryResponseDto(Post post) {
         this.postId = post.getPostId();
         this.title = post.getTitle();
         this.thumbImageUrl = post.getThumbImageUrl();

--- a/src/main/java/com/example/petner/domain/post/service/PostService.java
+++ b/src/main/java/com/example/petner/domain/post/service/PostService.java
@@ -68,9 +68,6 @@ public class PostService {
 
     @Transactional
     public PostResponseDto updatePost(Long postId, PostUpdateRequestDto request, Long currentUserId) {
-        memberRepository.findById(currentUserId)
-                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
-
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
 
@@ -89,9 +86,6 @@ public class PostService {
 
     @Transactional
     public PostDeleteResponseDto deletePost(Long postId, Long currentUserId) {
-        memberRepository.findById(currentUserId)
-                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
-
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
 

--- a/src/main/java/com/example/petner/domain/post/service/PostService.java
+++ b/src/main/java/com/example/petner/domain/post/service/PostService.java
@@ -2,10 +2,11 @@ package com.example.petner.domain.post.service;
 
 import com.example.petner.domain.member.entity.Member;
 import com.example.petner.domain.member.repository.MemberRepository;
-import com.example.petner.domain.post.dto.request.PostCreateRequest;
-import com.example.petner.domain.post.dto.response.PostResponse;
-import com.example.petner.domain.post.dto.response.PostSummaryResponse;
-import com.example.petner.domain.post.dto.request.PostUpdateRequest;
+import com.example.petner.domain.post.dto.request.PostCreateRequestDto;
+import com.example.petner.domain.post.dto.response.PostResponseDto;
+import com.example.petner.domain.post.dto.response.PostSummaryResponseDto;
+import com.example.petner.domain.post.dto.response.PostDeleteResponseDto;
+import com.example.petner.domain.post.dto.request.PostUpdateRequestDto;
 import com.example.petner.domain.post.repository.PostRepository;
 import com.example.petner.domain.post.entity.Post;
 import com.example.petner.global.exception.ErrorCode;
@@ -29,7 +30,7 @@ public class PostService {
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
-    public PostResponse createPost(Long authorId, PostCreateRequest request) {
+    public PostResponseDto createPost(Long authorId, PostCreateRequestDto request) {
         Member author = memberRepository.findById(authorId)
                 .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
 
@@ -45,11 +46,11 @@ public class PostService {
         // OpenSearch 동기화를 위한 이벤트 발행
         eventPublisher.publishEvent(PostEvent.created(savedPost.getPostId()));
 
-        return new PostResponse(savedPost);
+        return new PostResponseDto(savedPost);
     }
 
     @Transactional
-    public PostResponse getPost(Long postId) {
+    public PostResponseDto getPost(Long postId) {
         Post post = postRepository.findByIdWithAuthor(postId)
                 .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
         post.increaseViewCount();
@@ -57,16 +58,16 @@ public class PostService {
         // OpenSearch 동기화를 위한 이벤트 발행 (조회수 업데이트)
         eventPublisher.publishEvent(PostEvent.updated(postId));
 
-        return new PostResponse(post);
+        return new PostResponseDto(post);
     }
 
-    public Page<PostSummaryResponse> getPosts(Pageable pageable) {
+    public Page<PostSummaryResponseDto> getPosts(Pageable pageable) {
         return postRepository.findAllWithAuthor(pageable)
-                .map(PostSummaryResponse::new);
+                .map(PostSummaryResponseDto::new);
     }
 
     @Transactional
-    public PostResponse updatePost(Long postId, PostUpdateRequest request, Long currentUserId) {
+    public PostResponseDto updatePost(Long postId, PostUpdateRequestDto request, Long currentUserId) {
         memberRepository.findById(currentUserId)
                 .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
 
@@ -83,11 +84,11 @@ public class PostService {
         // OpenSearch 동기화를 위한 이벤트 발행
         eventPublisher.publishEvent(PostEvent.updated(postId));
 
-        return new PostResponse(post);
+        return new PostResponseDto(post);
     }
 
     @Transactional
-    public void deletePost(Long postId, Long currentUserId) {
+    public PostDeleteResponseDto deletePost(Long postId, Long currentUserId) {
         memberRepository.findById(currentUserId)
                 .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
 
@@ -103,5 +104,7 @@ public class PostService {
 
         // OpenSearch 동기화를 위한 이벤트 발행
         eventPublisher.publishEvent(PostEvent.deleted(postId));
+
+        return PostDeleteResponseDto.success(postId, currentUserId);
     }
 }


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
코드의 일관성과 유지보수성을 높이고, 불필요한 DB 조회를 줄여 성능을 개선하기 위해 리팩토링을 진행했습니다.
주요 변경 사항

1. DTO 파일명 및 삭제 응답 구조화: `Chat` 도메인과의 일관성을 위해 `Post` 및 `Comment` 도메인의 DTO 파일명에 `Dto` 접미사를 추가하고, 관련된 모든 `import` 구문을 수정했습니다. 또한, 하드코딩된 문자열을 반환하던 `delete` API의 성공 응답을 DTO를 사용하는 표준화된 방식으로 변경했습니다.
2. 서비스 로직 성능 개선: `Post` 서비스 로직에서 세션 검증 이후 불필요하게 `memberRepository`를 다시 조회하는 중복 로직을 제거하여 DB 접근을 최소화하고 성능을 향상시켰습니다.

<!--이슈 번호를 적어주세요(예시: fix #123). -->
#34

close #34

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?