### PR TITLE
[Feature] Favorite 도메인 Create, Read, Delete api 추가 - Feature/ddd 47

### DIFF
--- a/src/main/java/com/example/petner/domain/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/example/petner/domain/favorite/controller/FavoriteController.java
@@ -1,0 +1,121 @@
+package com.example.petner.domain.favorite.controller;
+
+import com.example.petner.domain.favorite.dto.request.FavoriteAddRequestDto;
+import com.example.petner.domain.favorite.dto.response.FavoriteActionResponseDto;
+import com.example.petner.domain.favorite.dto.response.FavoriteCheckResponseDto;
+import com.example.petner.domain.favorite.dto.response.FavoriteListResponseDto;
+import com.example.petner.domain.favorite.dto.response.FavoriteResponseDto;
+import com.example.petner.domain.favorite.service.FavoriteService;
+import com.example.petner.domain.favorite.service.FavoriteQueryService;
+import com.example.petner.global.annotation.SessionMember;
+import com.example.petner.global.dto.SessionUser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "즐겨찾기 (favorites)", description = "즐겨찾기 관련 API")
+@RestController
+@RequestMapping("/api/v1/favorites")
+@RequiredArgsConstructor
+public class FavoriteController {
+
+    private final FavoriteService favoriteService;
+    private final FavoriteQueryService favoriteQueryService;
+
+    /**
+     * 즐겨찾기 추가 API
+     *
+     * @param requestDto 즐겨찾기 추가 요청 데이터 (강아지 ID)
+     * @param user 세션에서 자동 주입되는 로그인 사용자 정보
+     * @return 추가된 즐겨찾기 정보 (201 Created)
+     *
+     * 비즈니스 로직:
+     * 1. 세션에서 로그인 사용자 정보 자동 추출
+     * 2. 요청된 강아지가 존재하는지 검증
+     * 3. 이미 즐겨찾기에 추가되어 있는지 중복 확인
+     * 4. 즐겨찾기 추가 및 결과 반환
+     */
+    @PostMapping("")
+    @Operation(summary = "즐겨찾기 추가", description = "강아지를 즐겨찾기에 추가합니다.")
+    @ApiResponse(responseCode = "201", description = "즐겨찾기 추가 성공")
+    public ResponseEntity<FavoriteResponseDto> addFavorite(
+            @RequestBody FavoriteAddRequestDto requestDto,
+            @SessionMember SessionUser user) {
+        FavoriteResponseDto responseDto = favoriteService.addFavorite(requestDto, user);
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    }
+
+    /**
+     * 즐겨찾기 제거 API
+     *
+     * @param dogId 제거할 강아지 ID
+     * @param user 세션에서 자동 주입되는 로그인 사용자 정보
+     * @return 처리 결과 (200 OK)
+     *
+     * 비즈니스 로직:
+     * 1. 세션에서 로그인 사용자 정보 자동 추출
+     * 2. 즐겨찾기 존재 여부 확인
+     * 3. 즐겨찾기 제거 처리
+     */
+    @DeleteMapping("/{dogId}")
+    @Operation(summary = "즐겨찾기 제거", description = "강아지를 즐겨찾기에서 제거합니다.")
+    @ApiResponse(responseCode = "200", description = "즐겨찾기 제거 성공")
+    public ResponseEntity<FavoriteActionResponseDto> removeFavorite(
+            @PathVariable Long dogId,
+            @SessionMember SessionUser user) {
+        favoriteService.removeFavorite(dogId, user);
+        FavoriteActionResponseDto responseDto = new FavoriteActionResponseDto(
+                user.getMemberId(), dogId, "즐겨찾기 제거 성공");
+        return ResponseEntity.ok(responseDto);
+    }
+
+    /**
+     * 내 즐겨찾기 목록 조회 API
+     *
+     * @param user 세션에서 자동 주입되는 로그인 사용자 정보
+     * @return 즐겨찾기 목록 (200 OK)
+     *
+     * 비즈니스 로직:
+     * 1. 세션에서 로그인 사용자 정보 자동 추출
+     * 2. 해당 사용자의 모든 즐겨찾기 조회
+     * 3. 강아지 상세 정보와 함께 반환
+     * 4. N+1 문제 방지를 위한 효율적인 조회 수행
+     */
+    @GetMapping("/my")
+    @Operation(summary = "내 즐겨찾기 목록 조회", description = "로그인한 사용자의 즐겨찾기 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "즐겨찾기 목록 조회 성공")
+    public ResponseEntity<List<FavoriteListResponseDto>> getMyFavorites(@SessionMember SessionUser user) {
+        List<FavoriteListResponseDto> favorites = favoriteQueryService.getMemberFavorites(user.getMemberId());
+        return ResponseEntity.ok(favorites);
+    }
+
+    /**
+     * 즐겨찾기 여부 확인 API
+     *
+     * @param dogId 확인할 강아지 ID
+     * @param user 세션에서 자동 주입되는 로그인 사용자 정보
+     * @return 즐겨찾기 여부 (200 OK)
+     *
+     * 비즈니스 로직:
+     * 1. 세션에서 로그인 사용자 정보 자동 추출
+     * 2. 특정 강아지에 대한 즐겨찾기 여부 확인
+     * 3. 구조화된 DTO로 결과 반환
+     */
+    @GetMapping("/check/{dogId}")
+    @Operation(summary = "즐겨찾기 여부 확인", description = "특정 강아지가 즐겨찾기에 있는지 확인합니다.")
+    @ApiResponse(responseCode = "200", description = "즐겨찾기 여부 확인 성공")
+    public ResponseEntity<FavoriteCheckResponseDto> checkFavorite(
+            @PathVariable Long dogId,
+            @SessionMember SessionUser user) {
+        boolean isFavorite = favoriteQueryService.isFavorite(user.getMemberId(), dogId);
+        FavoriteCheckResponseDto responseDto = new FavoriteCheckResponseDto(
+                user.getMemberId(), dogId, isFavorite);
+        return ResponseEntity.ok(responseDto);
+    }
+}

--- a/src/main/java/com/example/petner/domain/favorite/dto/request/FavoriteAddRequestDto.java
+++ b/src/main/java/com/example/petner/domain/favorite/dto/request/FavoriteAddRequestDto.java
@@ -1,0 +1,25 @@
+package com.example.petner.domain.favorite.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 즐겨찾기 추가 요청 DTO
+ *
+ * 클라이언트에서 서버로 즐겨찾기 추가 요청 시 사용하는 데이터 전송 객체입니다.
+ * 현재 로그인한 사용자의 정보는 세션에서 자동으로 가져오므로 강아지 ID만 필요합니다.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FavoriteAddRequestDto {
+
+    /**
+     * 즐겨찾기에 추가할 강아지 ID
+     */
+    private Long dogId;
+
+    public FavoriteAddRequestDto(Long dogId) {
+        this.dogId = dogId;
+    }
+}

--- a/src/main/java/com/example/petner/domain/favorite/dto/response/FavoriteActionResponseDto.java
+++ b/src/main/java/com/example/petner/domain/favorite/dto/response/FavoriteActionResponseDto.java
@@ -1,0 +1,37 @@
+package com.example.petner.domain.favorite.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 즐겨찾기 액션 응답 DTO
+ *
+ * 즐겨찾기 삭제 등의 액션 성공 시 사용하는 응답 DTO입니다.
+ * 처리 결과와 메시지를 포함합니다.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FavoriteActionResponseDto {
+
+    /**
+     * 처리된 멤버 ID
+     */
+    private Long memberId;
+
+    /**
+     * 처리된 강아지 ID
+     */
+    private Long dogId;
+
+    /**
+     * 처리 결과 메시지
+     */
+    private String message;
+
+    public FavoriteActionResponseDto(Long memberId, Long dogId, String message) {
+        this.memberId = memberId;
+        this.dogId = dogId;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/example/petner/domain/favorite/dto/response/FavoriteCheckResponseDto.java
+++ b/src/main/java/com/example/petner/domain/favorite/dto/response/FavoriteCheckResponseDto.java
@@ -1,0 +1,37 @@
+package com.example.petner.domain.favorite.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 즐겨찾기 여부 확인 응답 DTO
+ *
+ * 특정 강아지가 즐겨찾기에 추가되어 있는지 여부를 반환하는 DTO입니다.
+ * boolean 값 대신 구조화된 응답을 제공합니다.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FavoriteCheckResponseDto {
+
+    /**
+     * 확인한 멤버 ID
+     */
+    private Long memberId;
+
+    /**
+     * 확인한 강아지 ID
+     */
+    private Long dogId;
+
+    /**
+     * 즐겨찾기 여부
+     */
+    private boolean isFavorite;
+
+    public FavoriteCheckResponseDto(Long memberId, Long dogId, boolean isFavorite) {
+        this.memberId = memberId;
+        this.dogId = dogId;
+        this.isFavorite = isFavorite;
+    }
+}

--- a/src/main/java/com/example/petner/domain/favorite/dto/response/FavoriteListResponseDto.java
+++ b/src/main/java/com/example/petner/domain/favorite/dto/response/FavoriteListResponseDto.java
@@ -1,0 +1,75 @@
+package com.example.petner.domain.favorite.dto.response;
+
+import com.example.petner.domain.favorite.entity.Favorite;
+import com.example.petner.domain.dog.entity.Dog;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * 즐겨찾기 목록 응답 DTO
+ *
+ * 서버에서 클라이언트로 즐겨찾기 목록을 전달할 때 사용하는 데이터 전송 객체입니다.
+ * 강아지의 기본 정보와 즐겨찾기 정보를 함께 포함합니다.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FavoriteListResponseDto {
+
+    /**
+     * 즐겨찾기 고유 ID
+     */
+    private Long favoriteId;
+
+    /**
+     * 즐겨찾기 추가 일시
+     */
+    private LocalDateTime createdAt;
+
+    /**
+     * 강아지 정보
+     */
+    private DogInfo dogInfo;
+
+    /**
+     * Favorite 엔티티로부터 DTO를 생성하는 생성자
+     *
+     * @param favorite 변환할 Favorite 엔티티
+     */
+    public FavoriteListResponseDto(Favorite favorite) {
+        this.favoriteId = favorite.getFavoriteId();
+        this.createdAt = favorite.getCreatedAt();
+        this.dogInfo = new DogInfo(favorite.getDog());
+    }
+
+    /**
+     * 강아지 기본 정보를 담는 내부 클래스
+     */
+    @Getter
+    public static class DogInfo {
+        private final Long dogId;
+        private final String name;
+        private final String breedName;
+        private final String gender;
+        private final String dogSize;
+        private final BigDecimal weight;
+        private final String adoptionStatus;
+        private final String imageUrl;
+        private final String shelterName;
+
+        public DogInfo(Dog dog) {
+            this.dogId = dog.getDogId();
+            this.name = dog.getName();
+            this.breedName = dog.getBreed().getName();
+            this.gender = dog.getGender().name();
+            this.dogSize = dog.getDogSize().name();
+            this.weight = dog.getWeight();
+            this.adoptionStatus = dog.getAdoptionStatus().name();
+            this.imageUrl = dog.getImageUrl();
+            this.shelterName = dog.getShelter() != null ? dog.getShelter().getName() : null;
+        }
+    }
+}

--- a/src/main/java/com/example/petner/domain/favorite/dto/response/FavoriteResponseDto.java
+++ b/src/main/java/com/example/petner/domain/favorite/dto/response/FavoriteResponseDto.java
@@ -1,0 +1,51 @@
+package com.example.petner.domain.favorite.dto.response;
+
+import com.example.petner.domain.favorite.entity.Favorite;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 즐겨찾기 응답 DTO
+ *
+ * 서버에서 클라이언트로 즐겨찾기 정보를 전달할 때 사용하는 데이터 전송 객체입니다.
+ * 즐겨찾기 추가/제거 성공 시 응답으로 사용됩니다.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FavoriteResponseDto {
+
+    /**
+     * 즐겨찾기 고유 ID
+     */
+    private Long favoriteId;
+
+    /**
+     * 멤버 ID
+     */
+    private Long memberId;
+
+    /**
+     * 강아지 ID
+     */
+    private Long dogId;
+
+    /**
+     * 즐겨찾기 추가 일시
+     */
+    private LocalDateTime createdAt;
+
+    /**
+     * Favorite 엔티티로부터 DTO를 생성하는 생성자
+     *
+     * @param favorite 변환할 Favorite 엔티티
+     */
+    public FavoriteResponseDto(Favorite favorite) {
+        this.favoriteId = favorite.getFavoriteId();
+        this.memberId = favorite.getMember().getMemberId();
+        this.dogId = favorite.getDog().getDogId();
+        this.createdAt = favorite.getCreatedAt();
+    }
+}

--- a/src/main/java/com/example/petner/domain/favorite/entity/Favorite.java
+++ b/src/main/java/com/example/petner/domain/favorite/entity/Favorite.java
@@ -11,8 +11,15 @@ import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
 
+/**
+ * 즐겨찾기 엔티티
+ *
+ * 사용자가 관심있는 강아지를 즐겨찾기에 추가/제거할 수 있는 기능을 제공합니다.
+ * Member와 Dog 간의 다대다 관계를 중간 테이블로 표현합니다.
+ */
 @Entity
-@Table(name = "favorites")
+@Table(name = "favorites",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "dog_id"}))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Favorite {
@@ -22,10 +29,6 @@ public class Favorite {
     @Column(name = "favorite_id")
     private Long favoriteId;
 
-    @CreationTimestamp
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
@@ -33,6 +36,10 @@ public class Favorite {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "dog_id", nullable = false)
     private Dog dog;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
 
     @Builder
     public Favorite(Member member, Dog dog) {

--- a/src/main/java/com/example/petner/domain/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/com/example/petner/domain/favorite/repository/FavoriteRepository.java
@@ -11,19 +11,78 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * 즐겨찾기 Repository
+ *
+ * N+1 문제 방지를 위한 최적화된 쿼리 제공
+ * Member와 Dog 간의 즐겨찾기 관계 관리
+ */
 @Repository
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
 
+    /**
+     * 특정 멤버의 모든 즐겨찾기 조회
+     * @param member 멤버 엔티티
+     * @return 해당 멤버의 즐겨찾기 목록
+     */
     List<Favorite> findByMember(Member member);
 
+    /**
+     * 특정 강아지를 즐겨찾기한 모든 멤버 조회
+     * @param dog 강아지 엔티티
+     * @return 해당 강아지를 즐겨찾기한 목록
+     */
     List<Favorite> findByDog(Dog dog);
 
+    /**
+     * 특정 멤버와 강아지의 즐겨찾기 관계 조회
+     * @param member 멤버 엔티티
+     * @param dog 강아지 엔티티
+     * @return 즐겨찾기 관계
+     */
     Optional<Favorite> findByMemberAndDog(Member member, Dog dog);
 
+    /**
+     * 특정 멤버와 강아지의 즐겨찾기 관계 존재 여부 확인
+     * @param member 멤버 엔티티
+     * @param dog 강아지 엔티티
+     * @return 즐겨찾기 관계 존재 여부
+     */
     boolean existsByMemberAndDog(Member member, Dog dog);
 
-    @Query("SELECT f FROM Favorite f WHERE f.member = :member ORDER BY f.createdAt DESC")
-    List<Favorite> findByMemberOrderByCreatedAtDesc(@Param("member") Member member);
+    /**
+     * 특정 멤버의 즐겨찾기를 생성일 기준 내림차순으로 조회 (N+1 방지)
+     * @param memberId 멤버 ID
+     * @return 즐겨찾기 목록 (강아지 정보 포함)
+     */
+    @Query("SELECT f FROM Favorite f " +
+           "LEFT JOIN FETCH f.dog d " +
+           "LEFT JOIN FETCH d.breed " +
+           "LEFT JOIN FETCH d.member " +
+           "LEFT JOIN FETCH d.shelter " +
+           "WHERE f.member.memberId = :memberId " +
+           "ORDER BY f.createdAt DESC")
+    List<Favorite> findByMemberIdWithDogDetails(@Param("memberId") Long memberId);
 
+    /**
+     * 특정 멤버와 강아지 ID로 즐겨찾기 관계 존재 여부 확인
+     * @param memberId 멤버 ID
+     * @param dogId 강아지 ID
+     * @return 즐겨찾기 관계 존재 여부
+     */
+    boolean existsByMemberMemberIdAndDogDogId(Long memberId, Long dogId);
+
+    /**
+     * 특정 멤버와 강아지의 즐겨찾기 관계 삭제
+     * @param member 멤버 엔티티
+     * @param dog 강아지 엔티티
+     */
     void deleteByMemberAndDog(Member member, Dog dog);
+
+    /**
+     * 특정 멤버 ID와 강아지 ID로 즐겨찾기 관계 삭제
+     * @param memberId 멤버 ID
+     * @param dogId 강아지 ID
+     */
+    void deleteByMemberMemberIdAndDogDogId(Long memberId, Long dogId);
 }

--- a/src/main/java/com/example/petner/domain/favorite/service/FavoriteDuplicateChecker.java
+++ b/src/main/java/com/example/petner/domain/favorite/service/FavoriteDuplicateChecker.java
@@ -1,0 +1,44 @@
+package com.example.petner.domain.favorite.service;
+
+import com.example.petner.domain.favorite.repository.FavoriteRepository;
+import com.example.petner.global.exception.ErrorCode;
+import com.example.petner.global.exception.customException.FavoriteException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 즐겨찾기 중복 검사 서비스
+ *
+ * Single Responsibility Principle을 적용하여 중복 검사 책임만 담당
+ * 즐겨찾기 추가 시 중복 여부를 확인합니다.
+ */
+@Service
+@RequiredArgsConstructor
+public class FavoriteDuplicateChecker {
+
+    private final FavoriteRepository favoriteRepository;
+
+    /**
+     * 즐겨찾기 중복 여부 확인
+     *
+     * @param memberId 멤버 ID
+     * @param dogId 강아지 ID
+     * @throws FavoriteException 이미 즐겨찾기에 추가된 경우
+     */
+    public void checkDuplicate(Long memberId, Long dogId) {
+        if (favoriteRepository.existsByMemberMemberIdAndDogDogId(memberId, dogId)) {
+            throw new FavoriteException(ErrorCode.FAVORITE_ALREADY_EXISTS);
+        }
+    }
+
+    /**
+     * 즐겨찾기 존재 여부 확인 (예외 던지지 않음)
+     *
+     * @param memberId 멤버 ID
+     * @param dogId 강아지 ID
+     * @return 즐겨찾기 존재 여부
+     */
+    public boolean exists(Long memberId, Long dogId) {
+        return favoriteRepository.existsByMemberMemberIdAndDogDogId(memberId, dogId);
+    }
+}

--- a/src/main/java/com/example/petner/domain/favorite/service/FavoriteQueryService.java
+++ b/src/main/java/com/example/petner/domain/favorite/service/FavoriteQueryService.java
@@ -1,0 +1,49 @@
+package com.example.petner.domain.favorite.service;
+
+import com.example.petner.domain.favorite.dto.response.FavoriteListResponseDto;
+import com.example.petner.domain.favorite.entity.Favorite;
+import com.example.petner.domain.favorite.repository.FavoriteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 즐겨찾기 조회 전용 서비스
+ *
+ * Single Responsibility Principle을 적용하여 조회 책임만 담당
+ * N+1 문제를 방지한 효율적인 즐겨찾기 목록 조회를 제공합니다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FavoriteQueryService {
+
+    private final FavoriteRepository favoriteRepository;
+
+    /**
+     * 특정 멤버의 즐겨찾기 목록 조회
+     *
+     * @param memberId 멤버 ID
+     * @return 즐겨찾기 목록 (강아지 상세 정보 포함)
+     */
+    public List<FavoriteListResponseDto> getMemberFavorites(Long memberId) {
+        List<Favorite> favorites = favoriteRepository.findByMemberIdWithDogDetails(memberId);
+
+        return favorites.stream()
+                .map(FavoriteListResponseDto::new)
+                .toList();
+    }
+
+    /**
+     * 즐겨찾기 존재 여부 확인
+     *
+     * @param memberId 멤버 ID
+     * @param dogId 강아지 ID
+     * @return 즐겨찾기 존재 여부
+     */
+    public boolean isFavorite(Long memberId, Long dogId) {
+        return favoriteRepository.existsByMemberMemberIdAndDogDogId(memberId, dogId);
+    }
+}

--- a/src/main/java/com/example/petner/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/com/example/petner/domain/favorite/service/FavoriteService.java
@@ -1,0 +1,95 @@
+package com.example.petner.domain.favorite.service;
+
+import com.example.petner.domain.dog.entity.Dog;
+import com.example.petner.domain.favorite.dto.request.FavoriteAddRequestDto;
+import com.example.petner.domain.favorite.dto.response.FavoriteResponseDto;
+import com.example.petner.domain.favorite.entity.Favorite;
+import com.example.petner.domain.favorite.repository.FavoriteRepository;
+import com.example.petner.domain.member.entity.Member;
+import com.example.petner.global.dto.SessionUser;
+import com.example.petner.global.exception.ErrorCode;
+import com.example.petner.global.exception.customException.FavoriteException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 즐겨찾기 관리 서비스
+ *
+ * Single Responsibility Principle을 적용하여 즐겨찾기 추가/삭제 책임을 담당
+ * 세션 사용자 정보를 기반으로 즐겨찾기를 관리합니다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FavoriteService {
+
+    private final FavoriteRepository favoriteRepository;
+    private final FavoriteValidator favoriteValidator;
+    private final FavoriteDuplicateChecker duplicateChecker;
+
+    /**
+     * 즐겨찾기 추가
+     *
+     * @param requestDto 즐겨찾기 추가 요청 데이터
+     * @param user 세션에서 주입된 현재 로그인 사용자 정보
+     * @return 추가된 즐겨찾기 정보
+     *
+     * 처리 과정:
+     * 1. 세션 사용자 검증
+     * 2. 강아지 존재 여부 검증
+     * 3. 중복 즐겨찾기 확인
+     * 4. 즐겨찾기 생성 및 저장
+     */
+    @Transactional
+    public FavoriteResponseDto addFavorite(FavoriteAddRequestDto requestDto, SessionUser user) {
+        // 1. 세션 사용자 검증
+        Member member = favoriteValidator.validateAndGetMember(user.getMemberId());
+
+        // 2. 강아지 존재 여부 검증
+        Dog dog = favoriteValidator.validateAndGetDog(requestDto.getDogId());
+
+        // 3. 중복 즐겨찾기 확인
+        duplicateChecker.checkDuplicate(member.getMemberId(), dog.getDogId());
+
+        // 4. 즐겨찾기 생성 및 저장
+        Favorite favorite = Favorite.builder()
+                .member(member)
+                .dog(dog)
+                .build();
+
+        Favorite savedFavorite = favoriteRepository.save(favorite);
+
+        // 5. 응답 DTO로 변환하여 반환
+        return new FavoriteResponseDto(savedFavorite);
+    }
+
+    /**
+     * 즐겨찾기 제거
+     *
+     * @param dogId 제거할 강아지 ID
+     * @param user 세션에서 주입된 현재 로그인 사용자 정보
+     *
+     * 처리 과정:
+     * 1. 세션 사용자 검증
+     * 2. 강아지 존재 여부 검증
+     * 3. 즐겨찾기 존재 여부 확인
+     * 4. 즐겨찾기 삭제
+     */
+    @Transactional
+    public void removeFavorite(Long dogId, SessionUser user) {
+        // 1. 세션 사용자 검증
+        Member member = favoriteValidator.validateAndGetMember(user.getMemberId());
+
+        // 2. 강아지 존재 여부 검증
+        Dog dog = favoriteValidator.validateAndGetDog(dogId);
+
+        // 3. 즐겨찾기 존재 여부 확인
+        if (!duplicateChecker.exists(member.getMemberId(), dog.getDogId())) {
+            throw new FavoriteException(ErrorCode.FAVORITE_NOT_IN_MY_LIST);
+        }
+
+        // 4. 즐겨찾기 삭제
+        favoriteRepository.deleteByMemberMemberIdAndDogDogId(member.getMemberId(), dog.getDogId());
+    }
+}

--- a/src/main/java/com/example/petner/domain/favorite/service/FavoriteValidator.java
+++ b/src/main/java/com/example/petner/domain/favorite/service/FavoriteValidator.java
@@ -1,0 +1,49 @@
+package com.example.petner.domain.favorite.service;
+
+import com.example.petner.domain.dog.entity.Dog;
+import com.example.petner.domain.dog.repository.DogRepository;
+import com.example.petner.domain.member.entity.Member;
+import com.example.petner.domain.member.repository.MemberRepository;
+import com.example.petner.global.exception.ErrorCode;
+import com.example.petner.global.exception.customException.DogException;
+import com.example.petner.global.exception.customException.MemberException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 즐겨찾기 검증 서비스
+ *
+ * Single Responsibility Principle을 적용하여 검증 책임만 담당
+ * 멤버와 강아지의 존재 여부 및 유효성을 검증합니다.
+ */
+@Service
+@RequiredArgsConstructor
+public class FavoriteValidator {
+
+    private final MemberRepository memberRepository;
+    private final DogRepository dogRepository;
+
+    /**
+     * 멤버 존재 여부 검증 및 반환
+     *
+     * @param memberId 검증할 멤버 ID
+     * @return 검증된 Member 엔티티
+     * @throws MemberException 멤버가 존재하지 않을 경우
+     */
+    public Member validateAndGetMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    /**
+     * 강아지 존재 여부 검증 및 반환
+     *
+     * @param dogId 검증할 강아지 ID
+     * @return 검증된 Dog 엔티티
+     * @throws DogException 강아지가 존재하지 않을 경우
+     */
+    public Dog validateAndGetDog(Long dogId) {
+        return dogRepository.findById(dogId)
+                .orElseThrow(() -> new DogException(ErrorCode.DOG_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/example/petner/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/petner/global/exception/ErrorCode.java
@@ -52,6 +52,7 @@ public enum ErrorCode {
     /* 즐겨찾기 관련 */
     FAVORITE_NOT_FOUND("404-FV01", "즐겨찾기를 찾을 수 없습니다", HttpStatus.NOT_FOUND),
     FAVORITE_ALREADY_EXISTS("409-FV02", "이미 즐겨찾기에 추가된 항목입니다", HttpStatus.CONFLICT),
+    FAVORITE_NOT_IN_MY_LIST("400-FV03", "내 즐겨찾기 목록에 없는 강아지입니다", HttpStatus.BAD_REQUEST),
 
     /* 위치 관련 */
     LOCATION_NOT_FOUND("404-LC01", "위치 정보를 찾을 수 없습니다", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/example/petner/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/petner/global/exception/GlobalExceptionHandler.java
@@ -35,7 +35,9 @@ public class GlobalExceptionHandler {
             DogException.class,
             PostException.class,
             ChatException.class,
-            CommentException.class
+            CommentException.class,
+            ShelterException.class,
+            FavoriteException.class
     })
     public ResponseEntity<ErrorPayload> handleCustomException(RuntimeException ex, HttpServletRequest request) {
         ErrorCode errorCode = extractErrorCode(ex);

--- a/src/main/java/com/example/petner/global/exception/customException/FavoriteException.java
+++ b/src/main/java/com/example/petner/global/exception/customException/FavoriteException.java
@@ -1,0 +1,11 @@
+package com.example.petner.global.exception.customException;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import com.example.petner.global.exception.ErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public class FavoriteException extends RuntimeException {
+    private final ErrorCode errorCode;
+}


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->

# 연관 이슈 및 Close 할 이슈 작성

사용자의 **관심 목록(즐겨찾기)**을 추가, 제거, 조회할 수 있는 favorite 도메인을 구현했습니다. 기존 chat 도메인의 코드 구조와 컨벤션을 참고하여 프로젝트의 일관성을 유지했으며, SOLID 원칙을 적용하고 N+1 문제를 해결하여 코드 품질을 높였습니다.

Closes #47 

# Pull Request 체크리스트

- [x] 🔥 Favorite 도메인 구현: Entity, Repository, DTO, Service, Controller 구현

- [x] 🔥 N+1 문제 해결: fetch join을 사용하여 즐겨찾기 목록 조회 성능 최적화

- [x] 🔥 Exception 처리 강화: FavoriteException 및 관련 ErrorCode를 추가하여 명확한 에러 처리(GlobalExceptionHandler에 누락된 클래스 추가)

- [x] 🔥 버그 수정 및 개선: 즐겨찾기 삭제 로직 오류를 수정하고 API 응답 형식을 DTO로 통일

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat: 깃허브 로그인 버튼 컴포넌트 구현 (#10)
    - 나쁜 예시) feat: 로그인 구현