### PR TITLE
[Feature] Comment Soft Delete 기능 구현 - feature/ddd-43

### DIFF
--- a/src/main/java/com/example/petner/domain/comment/dto/response/CommentResponseDto.java
+++ b/src/main/java/com/example/petner/domain/comment/dto/response/CommentResponseDto.java
@@ -20,7 +20,7 @@ public class CommentResponseDto {
 
     public CommentResponseDto(Comment comment) {
         this.commentId = comment.getCommentId();
-        this.content = comment.getContent();
+        this.content = comment.isDeleted() ? "삭제된 댓글입니다." : comment.getContent();
         this.authorNickname = comment.getMember().getNickname();
         this.createdAt = comment.getCreatedAt();
         this.updatedAt = comment.getUpdatedAt();

--- a/src/main/java/com/example/petner/domain/comment/entity/Comment.java
+++ b/src/main/java/com/example/petner/domain/comment/entity/Comment.java
@@ -36,6 +36,9 @@ public class Comment {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
@@ -62,5 +65,13 @@ public class Comment {
 
     public boolean isReply() {
         return this.parentComment != null;
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
+    }
+
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/example/petner/domain/comment/entity/Comment.java
+++ b/src/main/java/com/example/petner/domain/comment/entity/Comment.java
@@ -4,6 +4,7 @@ import com.example.petner.domain.member.entity.Member;
 import com.example.petner.domain.post.entity.Post;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,6 +19,8 @@ import java.util.List;
 @Table(name = "comments")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class Comment {
 
     @Id
@@ -51,13 +54,6 @@ public class Comment {
     @JoinColumn(name = "parent_comment_id")
     private Comment parentComment;
 
-    @Builder
-    public Comment(String content, Post post, Member member, Comment parentComment) {
-        this.content = content;
-        this.post = post;
-        this.member = member;
-        this.parentComment = parentComment;
-    }
 
     public void update(String content) {
         this.content = content;
@@ -65,6 +61,10 @@ public class Comment {
 
     public boolean isReply() {
         return this.parentComment != null;
+    }
+
+    public boolean isNestedReply() {
+        return this.parentComment != null && this.parentComment.isReply();
     }
 
     public boolean isDeleted() {

--- a/src/main/java/com/example/petner/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/petner/domain/comment/repository/CommentRepository.java
@@ -21,17 +21,20 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("SELECT c FROM Comment c JOIN FETCH c.member WHERE c.post = :post AND c.parentComment IS NULL ORDER BY c.createdAt ASC")
     List<Comment> findParentCommentsByPost(@Param("post") Post post);
 
-    @Query("SELECT c FROM Comment c JOIN FETCH c.member WHERE c.parentComment = :parentComment ORDER BY c.createdAt ASC")
+    @Query("SELECT c FROM Comment c JOIN FETCH c.member WHERE c.parentComment = :parentComment " +
+           "AND c.deletedAt IS NULL ORDER BY c.createdAt ASC")
     List<Comment> findRepliesByParentComment(@Param("parentComment") Comment parentComment);
 
-    @Query("SELECT c FROM Comment c JOIN FETCH c.member WHERE c.post = :post ORDER BY c.createdAt ASC")
+    @Query("SELECT c FROM Comment c JOIN FETCH c.member WHERE c.post = :post " +
+           "AND (c.deletedAt IS NULL OR (c.deletedAt IS NOT NULL AND EXISTS " +
+           "(SELECT 1 FROM Comment r WHERE r.parentComment = c AND r.deletedAt IS NULL))) " +
+           "ORDER BY c.createdAt ASC")
     List<Comment> findByPostOrderByCreatedAtAsc(@Param("post") Post post);
 
     @Query("SELECT c FROM Comment c JOIN FETCH c.member WHERE c.commentId = :commentId")
     Optional<Comment> findByIdWithMember(@Param("commentId") Long commentId);
 
-    @Query("SELECT c FROM Comment c JOIN FETCH c.member JOIN FETCH c.post WHERE c.commentId = :commentId")
-    Optional<Comment> findByIdWithMemberAndPost(@Param("commentId") Long commentId);
 
-    Long countByPost(Post post);
+    @Query("SELECT COUNT(c) > 0 FROM Comment c WHERE c.parentComment = :parentComment AND c.deletedAt IS NULL")
+    boolean existsActiveReplies(@Param("parentComment") Comment parentComment);
 }

--- a/src/main/java/com/example/petner/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/petner/domain/comment/service/CommentService.java
@@ -100,16 +100,29 @@ public class CommentService {
 
     @Transactional
     public CommentDeleteResponseDto deleteComment(Long commentId, Long currentUserId) {
+        Comment comment = validateDeletePermission(commentId, currentUserId);
+        executeDelete(comment);
+        return CommentDeleteResponseDto.success(commentId, currentUserId);
+    }
+
+    private Comment validateDeletePermission(Long commentId, Long currentUserId) {
         Comment comment = commentRepository.findByIdWithMember(commentId)
                 .orElseThrow(() -> new CommentException(ErrorCode.COMMENT_NOT_FOUND));
 
-        // 댓글 작성자와 삭제 요청자가 동일한지 확인
         if (!comment.getMember().getMemberId().equals(currentUserId)) {
             throw new CommentException(ErrorCode.COMMENT_ACCESS_DENIED);
         }
 
-        commentRepository.delete(comment);
+        return comment;
+    }
 
-        return CommentDeleteResponseDto.success(commentId, currentUserId);
+    private void executeDelete(Comment comment) {
+        boolean hasReplies = commentRepository.existsActiveReplies(comment);
+
+        if (hasReplies) {
+            comment.delete();
+        } else {
+            commentRepository.delete(comment);
+        }
     }
 }

--- a/src/main/java/com/example/petner/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/petner/domain/comment/service/CommentService.java
@@ -47,6 +47,11 @@ public class CommentService {
             if (!parentComment.getPost().getPostId().equals(postId)) {
                 throw new CommentException(ErrorCode.COMMENT_POST_MISMATCH);
             }
+
+            // 2-depth 제한: 대댓글의 대댓글은 불가
+            if (parentComment.isReply()) {
+                throw new CommentException(ErrorCode.COMMENT_MAX_DEPTH_EXCEEDED);
+            }
         }
 
         Comment comment = Comment.builder()

--- a/src/main/java/com/example/petner/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/petner/global/exception/ErrorCode.java
@@ -44,6 +44,7 @@ public enum ErrorCode {
     COMMENT_NOT_FOUND("404-CM01", "댓글을 찾을 수 없습니다", HttpStatus.NOT_FOUND),
     COMMENT_ACCESS_DENIED("403-CM02", "댓글에 대한 접근 권한이 없습니다", HttpStatus.FORBIDDEN),
     COMMENT_POST_MISMATCH("400-CM03", "댓글과 게시글이 일치하지 않습니다", HttpStatus.BAD_REQUEST),
+    COMMENT_MAX_DEPTH_EXCEEDED("400-CM04", "댓글은 2단계까지만 작성 가능합니다", HttpStatus.BAD_REQUEST),
 
     /* 보호소 관련 */
     SHELTER_NOT_FOUND("404-SH01", "보호소 정보를 찾을 수 없습니다", HttpStatus.NOT_FOUND),

--- a/src/main/resources/db/migration/V20250925171606__Add_deleted_at_to_comments.sql
+++ b/src/main/resources/db/migration/V20250925171606__Add_deleted_at_to_comments.sql
@@ -1,0 +1,1 @@
+ALTER TABLE comments ADD COLUMN deleted_at TIMESTAMP NULL;


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
대댓글이 있는 부모 댓글은 삭제할 수 없는 문제를 해결하기 위해 물리적 삭제(Hard Delete)에서 논리적 삭제(Soft Delete) 방식으로 변경하였습니다.

기존에는 참조 무결성 제약 조건으로 인해 대댓글이 달린 부모 댓글을 삭제할 수 없었습니다. 이제는 부모 댓글을 삭제하더라도 물리적으로 데이터를 제거하는 대신, 삭제 상태로 변경하여 대댓글 구조를 그대로 유지합니다.

사용자에게는 **"삭제된 댓글입니다."** 와 같이 표시되어 서비스 흐름을 방해하지 않으면서도, 데이터는 보존하여 무결성을 지킬 수 있게 되었습니다.

2-depth만 지원합니다.

# 연관 이슈 및 Close 할 이슈 작성
<!--이슈 번호를 적어주세요(예시: fix #123). -->
#43

close #43

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?