### PR TITLE
[Refactor] 댓글 수정/삭제 API의 Post 검증 로직 추가 - refactor/ddd-54

### DIFF
--- a/src/main/java/com/example/petner/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/example/petner/domain/comment/controller/CommentController.java
@@ -48,26 +48,28 @@ public class CommentController {
         return ResponseEntity.ok(response);
     }
 
-    @PatchMapping("/comments/{commentId}")
-    @Operation(summary = "댓글 수정", description = "특정 댓글을 수정합니다.")
+    @PatchMapping("/posts/{postId}/comments/{commentId}")
+    @Operation(summary = "댓글 수정", description = "특정 게시물의 댓글을 수정합니다.")
     @ApiResponse(responseCode = "200", description = "댓글 수정 성공")
     public ResponseEntity<CommentResponseDto> updateComment(
+            @Parameter(description = "게시물 ID") @PathVariable Long postId,
             @Parameter(description = "댓글 ID") @PathVariable Long commentId,
             @Valid @RequestBody CommentUpdateRequestDto request,
             @SessionMember SessionUser user) {
 
-        CommentResponseDto response = commentService.updateComment(commentId, user.getMemberId(), request);
+        CommentResponseDto response = commentService.updateComment(postId, commentId, user.getMemberId(), request);
         return ResponseEntity.ok(response);
     }
 
-    @DeleteMapping("/comments/{commentId}")
-    @Operation(summary = "댓글 삭제", description = "특정 댓글을 삭제합니다.")
+    @DeleteMapping("/posts/{postId}/comments/{commentId}")
+    @Operation(summary = "댓글 삭제", description = "특정 게시물의 댓글을 삭제합니다.")
     @ApiResponse(responseCode = "200", description = "댓글 삭제 성공")
     public ResponseEntity<CommentDeleteResponseDto> deleteComment(
+            @Parameter(description = "게시물 ID") @PathVariable Long postId,
             @Parameter(description = "댓글 ID") @PathVariable Long commentId,
             @SessionMember SessionUser user) {
 
-        CommentDeleteResponseDto response = commentService.deleteComment(commentId, user.getMemberId());
+        CommentDeleteResponseDto response = commentService.deleteComment(postId, commentId, user.getMemberId());
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/petner/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/petner/domain/comment/service/CommentService.java
@@ -89,9 +89,18 @@ public class CommentService {
     }
 
     @Transactional
-    public CommentResponseDto updateComment(Long commentId, Long currentUserId, CommentUpdateRequestDto request) {
+    public CommentResponseDto updateComment(Long postId, Long commentId, Long currentUserId, CommentUpdateRequestDto request) {
+        // 게시물 존재 확인
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
+
         Comment comment = commentRepository.findByIdWithMember(commentId)
                 .orElseThrow(() -> new CommentException(ErrorCode.COMMENT_NOT_FOUND));
+
+        // 댓글이 해당 게시물에 속하는지 확인
+        if (!comment.getPost().getPostId().equals(postId)) {
+            throw new CommentException(ErrorCode.COMMENT_POST_MISMATCH);
+        }
 
         // 댓글 작성자와 수정 요청자가 동일한지 확인
         if (!comment.getMember().getMemberId().equals(currentUserId)) {
@@ -104,15 +113,24 @@ public class CommentService {
     }
 
     @Transactional
-    public CommentDeleteResponseDto deleteComment(Long commentId, Long currentUserId) {
-        Comment comment = validateDeletePermission(commentId, currentUserId);
+    public CommentDeleteResponseDto deleteComment(Long postId, Long commentId, Long currentUserId) {
+        Comment comment = validateDeletePermission(postId, commentId, currentUserId);
         executeDelete(comment);
         return CommentDeleteResponseDto.success(commentId, currentUserId);
     }
 
-    private Comment validateDeletePermission(Long commentId, Long currentUserId) {
+    private Comment validateDeletePermission(Long postId, Long commentId, Long currentUserId) {
+        // 게시물 존재 확인
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
+
         Comment comment = commentRepository.findByIdWithMember(commentId)
                 .orElseThrow(() -> new CommentException(ErrorCode.COMMENT_NOT_FOUND));
+
+        // 댓글이 해당 게시물에 속하는지 확인
+        if (!comment.getPost().getPostId().equals(postId)) {
+            throw new CommentException(ErrorCode.COMMENT_POST_MISMATCH);
+        }
 
         if (!comment.getMember().getMemberId().equals(currentUserId)) {
             throw new CommentException(ErrorCode.COMMENT_ACCESS_DENIED);


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
댓글(Comment) 도메인의 수정 및 삭제 API 구조를 개선했습니다.

기존 API(`PATCH/DELETE /comments/{commentId}`)는 `commentId`만으로 댓글에 접근하여, 해당 댓글이 올바른 게시글(Post)에 속해 있는지 검증하는 로직이 없었습니다. 이로 인해 의도치 않은 데이터 수정/삭제가 발생할 수 있는 잠재적 문제가 있었습니다.

이를 해결하기 위해 API 엔드포인트에 `postId`를 포함하도록 변경하고, 서비스 로직에 게시글 소속 여부를 확인하는 검증 로직을 추가했습니다.

**주요 변경 사항**

- **API 엔드포인트 변경으로 URL 일관성 확보**

  - `PATCH /comments/{commentId}` → `PATCH /posts/{postId}/comments/{commentId}`

  - `DELETE /comments/{commentId}` → `DELETE /posts/{postId}/comments/{commentId}`

- **보안 강화**

  - URL로 전달받은 `postId`와 댓글이 실제로 참조하는 `postId`를 비교하여, 다른 게시글의 댓글을 수정/삭제하는 것을 방지합니다.

- **API 명세의 명확성 증대**

  - API 경로만으로 어떤 게시글에 속한 댓글을 대상으로 하는지 명확하게 알 수 있습니다.

# 연관 이슈 및 Close 할 이슈 작성
<!--이슈 번호를 적어주세요(예시: fix #123). -->
#54

close #54

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?