### PR TITLE
[Feature] GCS Presigned URL을 이용한 파일 업로드 기능 개발 - feature/ddd-61

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ out/
 .env
 .env.local
 .env.*.local
+
+### Google Cloud Service Account Keys ###
+src/main/resources/service-key.json

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,12 @@ repositories {
     mavenCentral()
 }
 
+dependencyManagement {
+    imports {
+        mavenBom 'com.google.cloud:spring-cloud-gcp-dependencies:5.7.0'
+    }
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -45,6 +51,9 @@ dependencies {
     // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
+    // Google Cloud Storage
+    implementation 'com.google.cloud:spring-cloud-gcp-starter-storage'
 
     runtimeOnly 'org.postgresql:postgresql'
     testRuntimeOnly 'com.h2database:h2'

--- a/src/main/java/com/example/petner/domain/dog/service/DogService.java
+++ b/src/main/java/com/example/petner/domain/dog/service/DogService.java
@@ -9,11 +9,13 @@ import com.example.petner.domain.dog.entity.Dog;
 import com.example.petner.domain.dog.repository.DogRepository;
 import com.example.petner.domain.member.entity.Member;
 import com.example.petner.domain.shelter.entity.Shelter;
+import com.example.petner.domain.upload.service.UploadService;
 import com.example.petner.global.dto.SessionUser;
 import com.example.petner.global.exception.ErrorCode;
 import com.example.petner.global.exception.customException.DogException;
 import com.example.petner.search.event.DogEvent;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -30,6 +32,7 @@ import java.util.stream.Collectors;
  * 유기견 CRUD 기능을 제공하는 서비스 클래스
  * SOLID 원칙을 준수하여 리팩토링된 버전
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -39,6 +42,7 @@ public class DogService {
     private final DogValidator dogValidator;
     private final DogUpdater dogUpdater;
     private final ApplicationEventPublisher eventPublisher;
+    private final UploadService uploadService;
 
     /**
      * 유기견 등록
@@ -190,10 +194,22 @@ public class DogService {
         // 2. 권한 검증 (본인이 등록한 유기견인지 확인)
         dogValidator.validateDogAccess(dog, user);
 
-        // 3. 삭제 수행
+        // 3. GCP Storage에서 이미지 삭제
+        if (dog.getImageUrl() != null && !dog.getImageUrl().isBlank()) {
+            try {
+                uploadService.deleteImageFromStorage(dog.getImageUrl());
+            } catch (Exception e) {
+                // 이미지 삭제 실패 시 로그는 남기지만 DB 삭제는 계속 진행
+                // (이미지가 이미 삭제되었거나 네트워크 이슈일 수 있음)
+                log.warn("강아지 삭제 중 이미지 삭제 실패 (dogId: {}, imageUrl: {}): {}",
+                        dogId, dog.getImageUrl(), e.getMessage());
+            }
+        }
+
+        // 4. DB에서 삭제 수행
         dogRepository.delete(dog);
 
-        // 4. OpenSearch 동기화를 위한 이벤트 발행
+        // 5. OpenSearch 동기화를 위한 이벤트 발행
         eventPublisher.publishEvent(DogEvent.deleted(dogId));
     }
 }

--- a/src/main/java/com/example/petner/domain/upload/controller/UploadController.java
+++ b/src/main/java/com/example/petner/domain/upload/controller/UploadController.java
@@ -1,0 +1,77 @@
+package com.example.petner.domain.upload.controller;
+
+import com.example.petner.domain.upload.dto.response.DownloadUrlResponseDto;
+import com.example.petner.domain.upload.dto.response.UploadUrlResponseDto;
+import com.example.petner.global.exception.ErrorCode;
+import com.example.petner.global.exception.customException.UploadException;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.HttpMethod;
+import com.google.cloud.storage.Storage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URL;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@RestController
+@RequestMapping("/api/v1/upload")
+@RequiredArgsConstructor
+public class UploadController {
+
+    private final Storage storage;
+    @Value("${GCP_BUCKET}")
+    private String bucketName;
+
+    // Presigned URL 생성 (파일 업로드)
+    @GetMapping("/presigned-url")
+    public ResponseEntity<UploadUrlResponseDto> generatePresignedUrl(
+            @RequestParam String fileName, @RequestParam(required = false) String fileType) {
+        // 기본값으로 image/* 만 허용
+        if (fileType == null || fileType.isBlank() || !fileType.startsWith("image/")) {
+            throw new UploadException(ErrorCode.UPLOAD_INVALID_FILE_TYPE);
+        }
+
+        try {
+            // UUID를 파일명에 적용하여 고유한 객체명 생성
+            String uniqueFileName = UUID.randomUUID() + "_" + fileName;
+            BlobInfo blobInfo = BlobInfo.newBuilder(bucketName, uniqueFileName).build();
+
+            // 5분 유효 기간의 presigned URL 생성
+            URL signedUrl = storage.signUrl(blobInfo, 5, TimeUnit.MINUTES,
+                    Storage.SignUrlOption.httpMethod(HttpMethod.PUT),
+                    Storage.SignUrlOption.withV4Signature());
+
+            return ResponseEntity.ok(new UploadUrlResponseDto(signedUrl.toString(), uniqueFileName));
+        } catch (Exception e) {
+            throw new UploadException(ErrorCode.UPLOAD_PRESIGNED_URL_GENERATION_FAILED);
+        }
+    }
+
+    // Presigned URL 생성 (파일 로드/다운로드)
+    @GetMapping("/presigned-url/download")
+    public ResponseEntity<DownloadUrlResponseDto> generatePresignedGetUrl(
+            @RequestParam String objectName) {
+        if (objectName == null || objectName.isBlank()) {
+            throw new UploadException(ErrorCode.UPLOAD_OBJECT_NOT_FOUND);
+        }
+
+        try {
+            BlobInfo blobInfo = BlobInfo.newBuilder(bucketName, objectName).build();
+
+            // 5분 유효 기간의 presigned URL 생성 (GET 방식)
+            URL signedUrl = storage.signUrl(blobInfo, 5, TimeUnit.MINUTES,
+                    Storage.SignUrlOption.httpMethod(HttpMethod.GET),
+                    Storage.SignUrlOption.withV4Signature());
+
+            return ResponseEntity.ok(new DownloadUrlResponseDto(signedUrl.toString()));
+        } catch (Exception e) {
+            throw new UploadException(ErrorCode.UPLOAD_DOWNLOAD_URL_GENERATION_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/example/petner/domain/upload/controller/UploadController.java
+++ b/src/main/java/com/example/petner/domain/upload/controller/UploadController.java
@@ -2,6 +2,8 @@ package com.example.petner.domain.upload.controller;
 
 import com.example.petner.domain.upload.dto.response.DownloadUrlResponseDto;
 import com.example.petner.domain.upload.dto.response.UploadUrlResponseDto;
+import com.example.petner.global.annotation.SessionMember;
+import com.example.petner.global.dto.SessionUser;
 import com.example.petner.global.exception.ErrorCode;
 import com.example.petner.global.exception.customException.UploadException;
 import com.google.cloud.storage.BlobInfo;
@@ -31,7 +33,9 @@ public class UploadController {
     // Presigned URL 생성 (파일 업로드)
     @GetMapping("/presigned-url")
     public ResponseEntity<UploadUrlResponseDto> generatePresignedUrl(
-            @RequestParam String fileName, @RequestParam(required = false) String fileType) {
+            @RequestParam String fileName,
+            @RequestParam(required = false) String fileType,
+            @SessionMember SessionUser user) {
         // 기본값으로 image/* 만 허용
         if (fileType == null || fileType.isBlank() || !fileType.startsWith("image/")) {
             throw new UploadException(ErrorCode.UPLOAD_INVALID_FILE_TYPE);
@@ -56,7 +60,8 @@ public class UploadController {
     // Presigned URL 생성 (파일 로드/다운로드)
     @GetMapping("/presigned-url/download")
     public ResponseEntity<DownloadUrlResponseDto> generatePresignedGetUrl(
-            @RequestParam String objectName) {
+            @RequestParam String objectName,
+            @SessionMember SessionUser user) {
         if (objectName == null || objectName.isBlank()) {
             throw new UploadException(ErrorCode.UPLOAD_OBJECT_NOT_FOUND);
         }

--- a/src/main/java/com/example/petner/domain/upload/dto/response/DownloadUrlResponseDto.java
+++ b/src/main/java/com/example/petner/domain/upload/dto/response/DownloadUrlResponseDto.java
@@ -1,0 +1,10 @@
+package com.example.petner.domain.upload.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DownloadUrlResponseDto {
+    private final String url;
+}

--- a/src/main/java/com/example/petner/domain/upload/dto/response/UploadUrlResponseDto.java
+++ b/src/main/java/com/example/petner/domain/upload/dto/response/UploadUrlResponseDto.java
@@ -1,0 +1,11 @@
+package com.example.petner.domain.upload.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UploadUrlResponseDto {
+    private final String url;
+    private final String objectName;
+}

--- a/src/main/java/com/example/petner/domain/upload/service/UploadService.java
+++ b/src/main/java/com/example/petner/domain/upload/service/UploadService.java
@@ -1,0 +1,83 @@
+package com.example.petner.domain.upload.service;
+
+import com.example.petner.global.exception.ErrorCode;
+import com.example.petner.global.exception.customException.UploadException;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.Storage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UploadService {
+
+    private final Storage storage;
+
+    @Value("${gcp.bucket}")
+    private String bucketName;
+
+    /**
+     * GCP Storage에서 파일 삭제
+     *
+     * @param imageUrl 삭제할 이미지의 전체 URL 또는 objectName
+     */
+    public void deleteImageFromStorage(String imageUrl) {
+        if (imageUrl == null || imageUrl.isBlank()) {
+            log.warn("이미지 URL이 비어있어 삭제를 건너뜁니다.");
+            return;
+        }
+
+        try {
+            String objectName = extractObjectNameFromUrl(imageUrl);
+            log.info("GCP Storage에서 파일 삭제 시도: {}", objectName);
+
+            boolean deleted = storage.delete(BlobId.of(bucketName, objectName));
+
+            if (deleted) {
+                log.info("GCP Storage에서 파일 삭제 성공: {}", objectName);
+            } else {
+                log.warn("GCP Storage에서 파일을 찾을 수 없음: {}", objectName);
+                // 파일이 이미 없는 경우는 예외를 던지지 않음 (중복 삭제 방지)
+            }
+        } catch (Exception e) {
+            log.error("GCP Storage 파일 삭제 실패: {}", imageUrl, e);
+            throw new UploadException(ErrorCode.UPLOAD_DELETE_FAILED);
+        }
+    }
+
+    /**
+     * URL에서 objectName 추출
+     *
+     * @param imageUrl 전체 URL 또는 objectName
+     * @return objectName
+     */
+    private String extractObjectNameFromUrl(String imageUrl) {
+        try {
+            // Case 1: 전체 GCP Storage URL인 경우
+            if (imageUrl.contains("storage.googleapis.com")) {
+                // https://storage.googleapis.com/bucket-name/objectName?query... 형태
+                String[] parts = imageUrl.split("/");
+                if (parts.length >= 5) {
+                    String objectNameWithQuery = parts[4]; // objectName?query...
+                    // Query parameter 제거
+                    return objectNameWithQuery.split("\\?")[0];
+                }
+            }
+
+            // Case 2: 이미 objectName인 경우 (UUID_filename.ext 형태)
+            if (imageUrl.matches("^[a-f0-9-]{36}_.*\\.[a-zA-Z0-9]+$")) {
+                return imageUrl;
+            }
+
+            // Case 3: 단순 파일명인 경우 그대로 반환
+            return imageUrl;
+
+        } catch (Exception e) {
+            log.error("URL에서 objectName 추출 실패: {}", imageUrl, e);
+            throw new UploadException(ErrorCode.UPLOAD_INVALID_URL_FORMAT);
+        }
+    }
+}

--- a/src/main/java/com/example/petner/global/config/WebConfig.java
+++ b/src/main/java/com/example/petner/global/config/WebConfig.java
@@ -29,7 +29,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**")
-                .allowedOrigins("http://localhost:3000", "http://localhost:5173")
+                .allowedOrigins("http://localhost:3000", "http://localhost:5173", "http://localhost:8080", "http://localhost:63345")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true)

--- a/src/main/java/com/example/petner/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/petner/global/exception/ErrorCode.java
@@ -70,7 +70,14 @@ public enum ErrorCode {
     CHAT_ALREADY_ADOPTED("409-CH08", "이미 입양된 강아지입니다", HttpStatus.CONFLICT),
     CHAT_INVALID_REQUEST("400-CH09", "잘못된 채팅 요청입니다.", HttpStatus.BAD_REQUEST),
     CHAT_DOG_NOT_FOUND("404-CH10", "강아지 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    CHAT_INVALID_SAME_MEMBER("400-CH11", "동일한 사용자끼리는 채팅을 할 수 없습니다.", HttpStatus.BAD_REQUEST);
+    CHAT_INVALID_SAME_MEMBER("400-CH11", "동일한 사용자끼리는 채팅을 할 수 없습니다.", HttpStatus.BAD_REQUEST),
+
+    /* 업로드 관련 */
+    UPLOAD_INVALID_FILE_TYPE("400-UP01", "지원하지 않는 파일 형식입니다", HttpStatus.BAD_REQUEST),
+    UPLOAD_FILE_SIZE_EXCEEDED("400-UP02", "파일 크기가 허용 범위를 초과했습니다", HttpStatus.BAD_REQUEST),
+    UPLOAD_PRESIGNED_URL_GENERATION_FAILED("500-UP03", "업로드 URL 생성에 실패했습니다", HttpStatus.INTERNAL_SERVER_ERROR),
+    UPLOAD_OBJECT_NOT_FOUND("404-UP04", "요청한 파일을 찾을 수 없습니다", HttpStatus.NOT_FOUND),
+    UPLOAD_DOWNLOAD_URL_GENERATION_FAILED("500-UP05", "다운로드 URL 생성에 실패했습니다", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String errorCode;
     private final String message;

--- a/src/main/java/com/example/petner/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/petner/global/exception/ErrorCode.java
@@ -77,7 +77,9 @@ public enum ErrorCode {
     UPLOAD_FILE_SIZE_EXCEEDED("400-UP02", "파일 크기가 허용 범위를 초과했습니다", HttpStatus.BAD_REQUEST),
     UPLOAD_PRESIGNED_URL_GENERATION_FAILED("500-UP03", "업로드 URL 생성에 실패했습니다", HttpStatus.INTERNAL_SERVER_ERROR),
     UPLOAD_OBJECT_NOT_FOUND("404-UP04", "요청한 파일을 찾을 수 없습니다", HttpStatus.NOT_FOUND),
-    UPLOAD_DOWNLOAD_URL_GENERATION_FAILED("500-UP05", "다운로드 URL 생성에 실패했습니다", HttpStatus.INTERNAL_SERVER_ERROR);
+    UPLOAD_DOWNLOAD_URL_GENERATION_FAILED("500-UP05", "다운로드 URL 생성에 실패했습니다", HttpStatus.INTERNAL_SERVER_ERROR),
+    UPLOAD_DELETE_FAILED("500-UP06", "파일 삭제에 실패했습니다", HttpStatus.INTERNAL_SERVER_ERROR),
+    UPLOAD_INVALID_URL_FORMAT("400-UP07", "잘못된 URL 형식입니다", HttpStatus.BAD_REQUEST);
 
     private final String errorCode;
     private final String message;

--- a/src/main/java/com/example/petner/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/petner/global/exception/GlobalExceptionHandler.java
@@ -37,7 +37,8 @@ public class GlobalExceptionHandler {
             ChatException.class,
             CommentException.class,
             ShelterException.class,
-            FavoriteException.class
+            FavoriteException.class,
+            UploadException.class
     })
     public ResponseEntity<ErrorPayload> handleCustomException(RuntimeException ex, HttpServletRequest request) {
         ErrorCode errorCode = extractErrorCode(ex);

--- a/src/main/java/com/example/petner/global/exception/customException/UploadException.java
+++ b/src/main/java/com/example/petner/global/exception/customException/UploadException.java
@@ -1,0 +1,11 @@
+package com.example.petner.global.exception.customException;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import com.example.petner.global.exception.ErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public class UploadException extends RuntimeException {
+    private final ErrorCode errorCode;
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -65,3 +65,7 @@ kakao.oauth.redirect-uri=${KAKAO_REDIRECT_URI}
 opensearch.host=${OPENSEARCH_HOST}
 opensearch.port=${OPENSEARCH_PORT}
 opensearch.protocol=${OPENSEARCH_PROTOCOL}
+
+# Google Cloud Storage Configuration
+spring.cloud.gcp.project-id=petner-bucket-2025
+spring.cloud.gcp.credentials.location=classpath:service-key.json

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -67,5 +67,6 @@ opensearch.port=${OPENSEARCH_PORT}
 opensearch.protocol=${OPENSEARCH_PROTOCOL}
 
 # Google Cloud Storage Configuration
-spring.cloud.gcp.project-id=petner-bucket-2025
-spring.cloud.gcp.credentials.location=classpath:service-key.json
+spring.cloud.gcp.project-id=${GCP_PROJECT_ID}
+spring.cloud.gcp.credentials.location=classpath:${GCP_CREDENTIALS_PATH}
+gcp.bucket=${GCP_BUCKET}

--- a/src/main/resources/static/upload/upload-test.html
+++ b/src/main/resources/static/upload/upload-test.html
@@ -98,6 +98,15 @@
     <div class="container">
         <h1>🚀 GCP Storage Upload Test</h1>
 
+        <!-- 로그인 섹션 -->
+        <div class="section">
+            <h2>🔐 로그인</h2>
+            <div id="loginStatus">로그인 상태 확인 중...</div>
+            <button onclick="checkLogin()" id="checkLoginBtn">로그인 상태 확인</button>
+            <button onclick="kakaoLogin()" id="loginBtn" style="display:none;">카카오 로그인</button>
+            <button onclick="logout()" id="logoutBtn" style="display:none;">로그아웃</button>
+        </div>
+
         <!-- 업로드 섹션 -->
         <div class="section">
             <h2>📤 파일 업로드</h2>
@@ -118,6 +127,72 @@
 
     <script>
         const API_BASE = 'http://localhost:8080/api/v1/upload';
+        const AUTH_API_BASE = 'http://localhost:8080/api/v1/auth/kakao';
+        const DOG_API_BASE = 'http://localhost:8080/api/v1/dogs';
+
+        // 페이지 로드 시 로그인 상태 확인
+        window.addEventListener('load', checkLogin);
+
+        // 로그인 상태 확인
+        async function checkLogin() {
+            try {
+                const response = await fetch(`${AUTH_API_BASE}/session`, {
+                    credentials: 'include'
+                });
+
+                if (response.ok) {
+                    const data = await response.json();
+                    updateLoginStatus(data.authenticated);
+                } else {
+                    updateLoginStatus(false);
+                }
+            } catch (error) {
+                console.error('로그인 상태 확인 실패:', error);
+                updateLoginStatus(false);
+            }
+        }
+
+        // 로그인 상태 UI 업데이트
+        function updateLoginStatus(isAuthenticated) {
+            const loginStatus = document.getElementById('loginStatus');
+            const loginBtn = document.getElementById('loginBtn');
+            const logoutBtn = document.getElementById('logoutBtn');
+
+            if (isAuthenticated) {
+                loginStatus.innerHTML = '<span style="color: green;">✅ 로그인 됨</span>';
+                loginBtn.style.display = 'none';
+                logoutBtn.style.display = 'inline-block';
+            } else {
+                loginStatus.innerHTML = '<span style="color: red;">❌ 로그인 필요</span>';
+                loginBtn.style.display = 'inline-block';
+                logoutBtn.style.display = 'none';
+            }
+        }
+
+        // 카카오 로그인
+        function kakaoLogin() {
+            window.location.href = `${AUTH_API_BASE}/login`;
+        }
+
+        // 로그아웃
+        async function logout() {
+            try {
+                const response = await fetch(`${AUTH_API_BASE}/logout`, {
+                    method: 'POST',
+                    credentials: 'include'
+                });
+
+                if (response.ok) {
+                    showResult(document.getElementById('loginStatus'), '로그아웃 성공', 'success');
+                    updateLoginStatus(false);
+                } else {
+                    showResult(document.getElementById('loginStatus'), '로그아웃 실패', 'error');
+                }
+            } catch (error) {
+                console.error('로그아웃 실패:', error);
+                showResult(document.getElementById('loginStatus'), '로그아웃 실패', 'error');
+            }
+        }
 
         // 파일 업로드 함수
         async function uploadFile() {
@@ -139,7 +214,9 @@
                 // 1. Presigned URL 요청
                 showResult(resultDiv, '업로드 URL 생성 중...', 'info');
 
-                const urlResponse = await fetch(`${API_BASE}/presigned-url?fileName=${encodeURIComponent(file.name)}&fileType=${encodeURIComponent(file.type)}`);
+                const urlResponse = await fetch(`${API_BASE}/presigned-url?fileName=${encodeURIComponent(file.name)}&fileType=${encodeURIComponent(file.type)}`, {
+                    credentials: 'include'
+                });
 
                 if (!urlResponse.ok) {
                     const errorData = await urlResponse.json();
@@ -203,7 +280,9 @@
             try {
                 showResult(resultDiv, '다운로드 URL 생성 중...', 'info');
 
-                const response = await fetch(`${API_BASE}/presigned-url/download?objectName=${encodeURIComponent(objectNameInput.value.trim())}`);
+                const response = await fetch(`${API_BASE}/presigned-url/download?objectName=${encodeURIComponent(objectNameInput.value.trim())}`, {
+                    credentials: 'include'
+                });
 
                 if (!response.ok) {
                     const errorData = await response.json();

--- a/src/main/resources/static/upload/upload-test.html
+++ b/src/main/resources/static/upload/upload-test.html
@@ -1,0 +1,266 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GCP Storage Upload Test</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 800px;
+            margin: 50px auto;
+            padding: 20px;
+            background-color: #f5f5f5;
+        }
+        .container {
+            background: white;
+            padding: 30px;
+            border-radius: 10px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        h1 {
+            color: #333;
+            text-align: center;
+            margin-bottom: 30px;
+        }
+        .section {
+            margin-bottom: 30px;
+            padding: 20px;
+            border: 1px solid #ddd;
+            border-radius: 5px;
+        }
+        .section h2 {
+            color: #555;
+            margin-top: 0;
+        }
+        input[type="file"], input[type="text"] {
+            width: 100%;
+            padding: 10px;
+            margin: 10px 0;
+            border: 1px solid #ccc;
+            border-radius: 5px;
+            box-sizing: border-box;
+        }
+        button {
+            background-color: #4CAF50;
+            color: white;
+            padding: 12px 24px;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
+            font-size: 16px;
+            margin: 5px;
+        }
+        button:hover {
+            background-color: #45a049;
+        }
+        button:disabled {
+            background-color: #cccccc;
+            cursor: not-allowed;
+        }
+        .result {
+            margin-top: 15px;
+            padding: 15px;
+            border-radius: 5px;
+            word-break: break-all;
+        }
+        .success {
+            background-color: #d4edda;
+            border: 1px solid #c3e6cb;
+            color: #155724;
+        }
+        .error {
+            background-color: #f8d7da;
+            border: 1px solid #f5c6cb;
+            color: #721c24;
+        }
+        .info {
+            background-color: #d1ecf1;
+            border: 1px solid #bee5eb;
+            color: #0c5460;
+        }
+        #progress {
+            width: 100%;
+            height: 20px;
+            margin: 10px 0;
+            display: none;
+        }
+        .image-preview {
+            max-width: 300px;
+            max-height: 300px;
+            margin: 10px 0;
+            border: 1px solid #ddd;
+            border-radius: 5px;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>🚀 GCP Storage Upload Test</h1>
+
+        <!-- 업로드 섹션 -->
+        <div class="section">
+            <h2>📤 파일 업로드</h2>
+            <input type="file" id="fileInput" accept="image/*">
+            <button onclick="uploadFile()" id="uploadBtn">업로드</button>
+            <progress id="progress" value="0" max="100"></progress>
+            <div id="uploadResult"></div>
+        </div>
+
+        <!-- 다운로드 섹션 -->
+        <div class="section">
+            <h2>📥 파일 다운로드</h2>
+            <input type="text" id="objectNameInput" placeholder="objectName을 입력하세요 (예: uuid_filename.jpg)">
+            <button onclick="downloadFile()">다운로드 URL 생성</button>
+            <div id="downloadResult"></div>
+        </div>
+    </div>
+
+    <script>
+        const API_BASE = 'http://localhost:8080/api/v1/upload';
+
+        // 파일 업로드 함수
+        async function uploadFile() {
+            const fileInput = document.getElementById('fileInput');
+            const uploadBtn = document.getElementById('uploadBtn');
+            const progress = document.getElementById('progress');
+            const resultDiv = document.getElementById('uploadResult');
+
+            if (!fileInput.files[0]) {
+                showResult(resultDiv, '파일을 선택해주세요.', 'error');
+                return;
+            }
+
+            const file = fileInput.files[0];
+            uploadBtn.disabled = true;
+            progress.style.display = 'block';
+
+            try {
+                // 1. Presigned URL 요청
+                showResult(resultDiv, '업로드 URL 생성 중...', 'info');
+
+                const urlResponse = await fetch(`${API_BASE}/presigned-url?fileName=${encodeURIComponent(file.name)}&fileType=${encodeURIComponent(file.type)}`);
+
+                if (!urlResponse.ok) {
+                    const errorData = await urlResponse.json();
+                    throw new Error(`URL 생성 실패: ${errorData.message || urlResponse.statusText}`);
+                }
+
+                const { url, objectName } = await urlResponse.json();
+
+                showResult(resultDiv, `업로드 URL 생성 성공! ObjectName: ${objectName}`, 'success');
+
+                // 2. 실제 파일 업로드
+                showResult(resultDiv, '파일 업로드 중...', 'info');
+
+                const uploadResponse = await fetch(url, {
+                    method: 'PUT',
+                    body: file,
+                    headers: {
+                        'Content-Type': file.type
+                    }
+                });
+
+                if (!uploadResponse.ok) {
+                    throw new Error(`업로드 실패: ${uploadResponse.statusText}`);
+                }
+
+                progress.value = 100;
+
+                // 결과 표시
+                const resultHtml = `
+                    <strong>✅ 업로드 성공!</strong><br>
+                    파일명: ${file.name}<br>
+                    타입: ${file.type}<br>
+                    크기: ${(file.size / 1024).toFixed(2)} KB<br>
+                    ObjectName: ${objectName}<br>
+                    <br>
+                    <button onclick="document.getElementById('objectNameInput').value='${objectName}'">다운로드 테스트하기</button>
+                `;
+
+                showResult(resultDiv, resultHtml, 'success');
+
+            } catch (error) {
+                console.error('Upload error:', error);
+                showResult(resultDiv, `❌ 업로드 실패: ${error.message}`, 'error');
+            } finally {
+                uploadBtn.disabled = false;
+                progress.style.display = 'none';
+                progress.value = 0;
+            }
+        }
+
+        // 파일 다운로드 URL 생성 함수
+        async function downloadFile() {
+            const objectNameInput = document.getElementById('objectNameInput');
+            const resultDiv = document.getElementById('downloadResult');
+
+            if (!objectNameInput.value.trim()) {
+                showResult(resultDiv, 'ObjectName을 입력해주세요.', 'error');
+                return;
+            }
+
+            try {
+                showResult(resultDiv, '다운로드 URL 생성 중...', 'info');
+
+                const response = await fetch(`${API_BASE}/presigned-url/download?objectName=${encodeURIComponent(objectNameInput.value.trim())}`);
+
+                if (!response.ok) {
+                    const errorData = await response.json();
+                    throw new Error(`다운로드 URL 생성 실패: ${errorData.message || response.statusText}`);
+                }
+
+                const { url } = await response.json();
+
+                // 이미지인 경우 미리보기 표시
+                const resultHtml = `
+                    <strong>✅ 다운로드 URL 생성 성공!</strong><br>
+                    ObjectName: ${objectNameInput.value}<br>
+                    <br>
+                    <a href="${url}" target="_blank" style="color: #007bff;">🔗 파일 다운로드/보기</a><br>
+                    <br>
+                    <img src="${url}" class="image-preview" alt="Image Preview"
+                         onerror="this.style.display='none'; this.nextSibling.style.display='block';">
+                    <div style="display:none; color: #666;">이미지 미리보기를 불러올 수 없습니다.</div>
+                `;
+
+                showResult(resultDiv, resultHtml, 'success');
+
+            } catch (error) {
+                console.error('Download error:', error);
+                showResult(resultDiv, `❌ 다운로드 URL 생성 실패: ${error.message}`, 'error');
+            }
+        }
+
+        // 결과 표시 함수
+        function showResult(element, message, type) {
+            element.innerHTML = message;
+            element.className = `result ${type}`;
+        }
+
+        // 파일 선택 시 미리보기
+        document.getElementById('fileInput').addEventListener('change', function(e) {
+            const file = e.target.files[0];
+            if (file && file.type.startsWith('image/')) {
+                const reader = new FileReader();
+                reader.onload = function(e) {
+                    const preview = document.createElement('img');
+                    preview.src = e.target.result;
+                    preview.className = 'image-preview';
+                    preview.alt = 'Selected file preview';
+
+                    // 기존 미리보기 제거
+                    const existingPreview = document.querySelector('#fileInput + .image-preview');
+                    if (existingPreview) {
+                        existingPreview.remove();
+                    }
+
+                    // 새 미리보기 추가
+                    document.getElementById('fileInput').insertAdjacentElement('afterend', preview);
+                };
+                reader.readAsDataURL(file);
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
Google Cloud Storage(GCS)를 이용한 파일 업로드 기능을 추가했습니다.

서버의 부하를 줄이고 보안을 강화하기 위해, 클라이언트가 서버로부터 서명된 URL을 발급받아 GCS에 직접 파일을 업로드하는 **Presigned URL** 방식을 도입했습니다.

로그인한 사용자만 Presigned URL을 생성할 수 있습니다.

**주요 구현 내용**
- 클라이언트의 요청에 따라 파일 업로드용(PUT) 및 조회용(GET) Presigned URL을 생성하는 API 엔드포인트를 구현했습니다.

- 파일명 중복을 방지하기 위해 UUID를 적용하여 GCS에 저장될 객체 이름을 고유하게 생성합니다.

- CORS 설정을 통해 로컬 개발 환경(`localhost`, `127.0.0.1`)에서의 파일 업로드 테스트를 지원합니다.

- Presigned URL 생성 API(`/api/v1/upload/`)에 세션 인증 요구사항을 추가했습니다.

# 연관 이슈 및 Close 할 이슈 작성
<!--이슈 번호를 적어주세요(예시: fix #123). -->
#61

close #61

# Pull Request 체크리스트

## TODO

- [ ] 최종 결과물을 확인했는가?
- [ ] 의미 있는 커밋 메시지를 작성했는가?