### PR TITLE
[Feature] 품종, 지역, 보호소 이름 기반 ID 조회 API 개발 - feature/ddd-65

### DIFF
--- a/src/main/java/com/example/petner/domain/breed/controller/BreedSearchController.java
+++ b/src/main/java/com/example/petner/domain/breed/controller/BreedSearchController.java
@@ -1,0 +1,29 @@
+package com.example.petner.domain.breed.controller;
+
+import com.example.petner.domain.breed.dto.response.BreedSearchResponseDto;
+import com.example.petner.domain.breed.service.BreedSearchService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/breeds")
+@RequiredArgsConstructor
+@Tag(name = "견종 (breeds)", description = "견종 관련 API")
+public class BreedSearchController {
+
+    private final BreedSearchService breedSearchService;
+
+    @GetMapping("/search")
+    @Operation(summary = "견종 이름으로 ID 조회", description = "견종 이름을 기반으로 해당 견종의 ID와 이름을 조회합니다.")
+    public ResponseEntity<BreedSearchResponseDto> searchBreedByName(
+            @Parameter(description = "검색할 견종 이름", example = "골든 리트리버")
+            @RequestParam String name) {
+
+        BreedSearchResponseDto result = breedSearchService.searchByName(name);
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/com/example/petner/domain/breed/dto/response/BreedSearchResponseDto.java
+++ b/src/main/java/com/example/petner/domain/breed/dto/response/BreedSearchResponseDto.java
@@ -1,0 +1,20 @@
+package com.example.petner.domain.breed.dto.response;
+
+import com.example.petner.domain.breed.entity.Breed;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BreedSearchResponseDto {
+
+    private Long breedId;
+    private String name;
+
+    public static BreedSearchResponseDto from(Breed breed) {
+        return BreedSearchResponseDto.builder()
+                .breedId(breed.getBreedId())
+                .name(breed.getName())
+                .build();
+    }
+}

--- a/src/main/java/com/example/petner/domain/breed/service/BreedSearchService.java
+++ b/src/main/java/com/example/petner/domain/breed/service/BreedSearchService.java
@@ -1,0 +1,25 @@
+package com.example.petner.domain.breed.service;
+
+import com.example.petner.domain.breed.dto.response.BreedSearchResponseDto;
+import com.example.petner.domain.breed.entity.Breed;
+import com.example.petner.domain.breed.repository.BreedRepository;
+import com.example.petner.global.exception.ErrorCode;
+import com.example.petner.global.exception.customException.DogException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BreedSearchService {
+
+    private final BreedRepository breedRepository;
+
+    public BreedSearchResponseDto searchByName(String name) {
+        Breed breed = breedRepository.findByName(name)
+                .orElseThrow(() -> new DogException(ErrorCode.DOG_BREED_NOT_FOUND));
+
+        return BreedSearchResponseDto.from(breed);
+    }
+}

--- a/src/main/java/com/example/petner/domain/location/controller/LocationSearchController.java
+++ b/src/main/java/com/example/petner/domain/location/controller/LocationSearchController.java
@@ -1,0 +1,29 @@
+package com.example.petner.domain.location.controller;
+
+import com.example.petner.domain.location.dto.response.LocationSearchResponseDto;
+import com.example.petner.domain.location.service.LocationSearchService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/locations")
+@RequiredArgsConstructor
+@Tag(name = "지역 (locations)", description = "지역 관련 API")
+public class LocationSearchController {
+
+    private final LocationSearchService locationSearchService;
+
+    @GetMapping("/search")
+    @Operation(summary = "지역 이름으로 ID 조회", description = "지역 이름을 기반으로 해당 지역의 ID와 이름을 조회합니다.")
+    public ResponseEntity<LocationSearchResponseDto> searchLocationByName(
+            @Parameter(description = "검색할 지역 이름 (시/도 구/군 형태)", example = "서울특별시 강남구")
+            @RequestParam String name) {
+
+        LocationSearchResponseDto result = locationSearchService.searchByName(name);
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/com/example/petner/domain/location/dto/response/LocationSearchResponseDto.java
+++ b/src/main/java/com/example/petner/domain/location/dto/response/LocationSearchResponseDto.java
@@ -1,0 +1,20 @@
+package com.example.petner.domain.location.dto.response;
+
+import com.example.petner.domain.location.entity.Location;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LocationSearchResponseDto {
+
+    private Long locationId;
+    private String name;
+
+    public static LocationSearchResponseDto from(Location location) {
+        return LocationSearchResponseDto.builder()
+                .locationId(location.getLocationId())
+                .name(location.getState() + " " + location.getDistrict())
+                .build();
+    }
+}

--- a/src/main/java/com/example/petner/domain/location/service/LocationSearchService.java
+++ b/src/main/java/com/example/petner/domain/location/service/LocationSearchService.java
@@ -1,0 +1,33 @@
+package com.example.petner.domain.location.service;
+
+import com.example.petner.domain.location.dto.response.LocationSearchResponseDto;
+import com.example.petner.domain.location.entity.Location;
+import com.example.petner.domain.location.repository.LocationRepository;
+import com.example.petner.global.exception.ErrorCode;
+import com.example.petner.global.exception.customException.LocationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LocationSearchService {
+
+    private final LocationRepository locationRepository;
+
+    public LocationSearchResponseDto searchByName(String name) {
+        String[] parts = name.trim().split("\\s+");
+        if (parts.length != 2) {
+            throw new LocationException(ErrorCode.LOCATION_INVALID);
+        }
+
+        String state = parts[0];
+        String district = parts[1];
+
+        Location location = locationRepository.findByStateAndDistrict(state, district)
+                .orElseThrow(() -> new LocationException(ErrorCode.LOCATION_NOT_FOUND));
+
+        return LocationSearchResponseDto.from(location);
+    }
+}

--- a/src/main/java/com/example/petner/domain/shelter/controller/ShelterSearchController.java
+++ b/src/main/java/com/example/petner/domain/shelter/controller/ShelterSearchController.java
@@ -1,0 +1,29 @@
+package com.example.petner.domain.shelter.controller;
+
+import com.example.petner.domain.shelter.dto.response.ShelterSearchResponseDto;
+import com.example.petner.domain.shelter.service.ShelterSearchService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/shelters")
+@RequiredArgsConstructor
+@Tag(name = "보호소 (shelters)", description = "보호소 관련 API")
+public class ShelterSearchController {
+
+    private final ShelterSearchService shelterSearchService;
+
+    @GetMapping("/search")
+    @Operation(summary = "보호소 이름으로 ID 조회", description = "보호소 이름을 기반으로 해당 보호소의 ID와 이름을 조회합니다.")
+    public ResponseEntity<ShelterSearchResponseDto> searchShelterByName(
+            @Parameter(description = "검색할 보호소 이름", example = "서울동물복지센터")
+            @RequestParam String name) {
+
+        ShelterSearchResponseDto result = shelterSearchService.searchByName(name);
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/com/example/petner/domain/shelter/dto/response/ShelterSearchResponseDto.java
+++ b/src/main/java/com/example/petner/domain/shelter/dto/response/ShelterSearchResponseDto.java
@@ -1,0 +1,20 @@
+package com.example.petner.domain.shelter.dto.response;
+
+import com.example.petner.domain.shelter.entity.Shelter;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ShelterSearchResponseDto {
+
+    private Long shelterId;
+    private String name;
+
+    public static ShelterSearchResponseDto from(Shelter shelter) {
+        return ShelterSearchResponseDto.builder()
+                .shelterId(shelter.getShelterId())
+                .name(shelter.getName())
+                .build();
+    }
+}

--- a/src/main/java/com/example/petner/domain/shelter/service/ShelterSearchService.java
+++ b/src/main/java/com/example/petner/domain/shelter/service/ShelterSearchService.java
@@ -1,0 +1,25 @@
+package com.example.petner.domain.shelter.service;
+
+import com.example.petner.domain.shelter.dto.response.ShelterSearchResponseDto;
+import com.example.petner.domain.shelter.entity.Shelter;
+import com.example.petner.domain.shelter.repository.ShelterRepository;
+import com.example.petner.global.exception.ErrorCode;
+import com.example.petner.global.exception.customException.ShelterException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ShelterSearchService {
+
+    private final ShelterRepository shelterRepository;
+
+    public ShelterSearchResponseDto searchByName(String name) {
+        Shelter shelter = shelterRepository.findByName(name)
+                .orElseThrow(() -> new ShelterException(ErrorCode.SHELTER_NOT_FOUND));
+
+        return ShelterSearchResponseDto.from(shelter);
+    }
+}

--- a/src/main/java/com/example/petner/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/petner/global/exception/GlobalExceptionHandler.java
@@ -37,6 +37,7 @@ public class GlobalExceptionHandler {
             ChatException.class,
             CommentException.class,
             ShelterException.class,
+            LocationException.class,
             FavoriteException.class,
             UploadException.class
     })

--- a/src/main/java/com/example/petner/global/exception/customException/LocationException.java
+++ b/src/main/java/com/example/petner/global/exception/customException/LocationException.java
@@ -1,0 +1,11 @@
+package com.example.petner.global.exception.customException;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import com.example.petner.global.exception.ErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public class LocationException extends RuntimeException {
+    private final ErrorCode errorCode;
+}


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
클라이언트에서 사용하는 문자열 이름(품종, 지역, 보호소)을 기반으로 DB의 고유 ID를 조회하는 API를 개발했습니다.

이 기능은 사용자가 `dog` 등록, 프로필 수정 등 이름으로 선택한 항목을 서버에서 외래 키(ID)로 변환하여 후속 작업을 처리하기 위해 필요합니다. 각 리소스에 대한 검색(필터링) 역할을 하므로, RESTful 원칙에 따라 쿼리 파라미터를 사용하는 방식으로 구현했습니다.

**주요 변경 사항**
- 품종 ID 조회 API 추가: `GET /api/v1/breeds/search?name={품종명}`
- 지역 ID 조회 API 추가: `GET /api/v1/locations/search?name={지역명}`
- 보호소 ID 조회 API 추가: `GET /api/v1/shelters/search?name={보호소명}`

# 연관 이슈 및 Close 할 이슈 작성
<!--이슈 번호를 적어주세요(예시: fix #123). -->
#65

close #65

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?