### PR TITLE
[Feature] GCS 이미지 라이프사이클 관리 로직 추가 (수정/삭제 동기화) - feature/ddd-67

### DIFF
--- a/src/main/java/com/example/petner/domain/dog/service/DogService.java
+++ b/src/main/java/com/example/petner/domain/dog/service/DogService.java
@@ -53,39 +53,55 @@ public class DogService {
      */
     @Transactional
     public DogResponseDto createDog(DogCreateRequestDto requestDto, SessionUser user) {
-        // 1. 사용자 검증
-        Member member = dogValidator.validateAndGetMember(user);
+        String imageUrl = requestDto.getImageUrl();
 
-        // 2. 견종 검증
-        Breed breed = dogValidator.validateAndGetBreed(requestDto.getBreedId());
+        try {
+            // 1. 사용자 검증
+            Member member = dogValidator.validateAndGetMember(user);
 
-        // 3. 보호소 검증 (선택적)
-        Shelter shelter = dogValidator.validateAndGetShelter(requestDto.getShelterId());
+            // 2. 견종 검증
+            Breed breed = dogValidator.validateAndGetBreed(requestDto.getBreedId());
 
-        // 4. 유기견 엔티티 생성
-        Dog dog = Dog.builder()
-                .name(requestDto.getName())
-                .breed(breed)
-                .birthDate(requestDto.getBirthDate())
-                .gender(requestDto.getGender())
-                .dogSize(requestDto.getDogSize())
-                .weight(requestDto.getWeight())
-                .healthStatus(requestDto.getHealthStatus())
-                .description(requestDto.getDescription())
-                .adoptionStatus(requestDto.getAdoptionStatus())
-                .imageUrl(requestDto.getImageUrl())
-                .member(member)
-                .shelter(shelter)
-                .build();
+            // 3. 보호소 검증 (선택적)
+            Shelter shelter = dogValidator.validateAndGetShelter(requestDto.getShelterId());
 
-        // 5. 데이터베이스에 저장
-        Dog savedDog = dogRepository.save(dog);
+            // 4. 유기견 엔티티 생성
+            Dog dog = Dog.builder()
+                    .name(requestDto.getName())
+                    .breed(breed)
+                    .birthDate(requestDto.getBirthDate())
+                    .gender(requestDto.getGender())
+                    .dogSize(requestDto.getDogSize())
+                    .weight(requestDto.getWeight())
+                    .healthStatus(requestDto.getHealthStatus())
+                    .description(requestDto.getDescription())
+                    .adoptionStatus(requestDto.getAdoptionStatus())
+                    .imageUrl(imageUrl)
+                    .member(member)
+                    .shelter(shelter)
+                    .build();
 
-        // 6. OpenSearch 동기화를 위한 이벤트 발행
-        eventPublisher.publishEvent(DogEvent.created(savedDog.getDogId()));
+            // 5. 데이터베이스에 저장
+            Dog savedDog = dogRepository.save(dog);
 
-        // 7. 응답 DTO 반환
-        return DogResponseDto.from(savedDog);
+            // 6. OpenSearch 동기화를 위한 이벤트 발행
+            eventPublisher.publishEvent(DogEvent.created(savedDog.getDogId()));
+
+            // 7. 응답 DTO 반환
+            return DogResponseDto.from(savedDog);
+
+        } catch (Exception e) {
+            // Dog 생성 실패 시 업로드된 이미지 삭제
+            if (imageUrl != null && !imageUrl.isBlank()) {
+                try {
+                    uploadService.deleteImageFromStorage(imageUrl);
+                    log.info("Dog 생성 실패로 인한 이미지 삭제 완료: {}", imageUrl);
+                } catch (Exception deleteException) {
+                    log.warn("Dog 생성 실패 후 이미지 삭제 실패: {}", imageUrl, deleteException);
+                }
+            }
+            throw e; // 원래 예외를 다시 던짐
+        }
     }
 
     /**

--- a/src/main/java/com/example/petner/domain/dog/service/DogUpdater.java
+++ b/src/main/java/com/example/petner/domain/dog/service/DogUpdater.java
@@ -4,6 +4,9 @@ import com.example.petner.domain.breed.entity.Breed;
 import com.example.petner.domain.dog.dto.request.DogUpdateRequestDto;
 import com.example.petner.domain.dog.entity.Dog;
 import com.example.petner.domain.shelter.entity.Shelter;
+import com.example.petner.domain.upload.service.UploadService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -11,14 +14,35 @@ import org.springframework.util.StringUtils;
  * 유기견 정보 업데이트를 담당하는 컴포넌트
  * Single Responsibility Principle(SRP)을 준수하여 업데이트 로직만 담당
  */
+@Slf4j
 @Component
+@RequiredArgsConstructor
 public class DogUpdater {
+
+    private final UploadService uploadService;
 
     /**
      * 유기견 정보 업데이트
      * null이 아닌 필드만 선택적으로 업데이트
      */
     public void updateDogInfo(Dog dog, DogUpdateRequestDto requestDto, Breed breed, Shelter shelter) {
+        String oldImageUrl = dog.getImageUrl();
+        String newImageUrl = StringUtils.hasText(requestDto.getImageUrl()) ? requestDto.getImageUrl() : dog.getImageUrl();
+
+        // 이미지 URL이 변경된 경우 기존 이미지 삭제
+        if (StringUtils.hasText(requestDto.getImageUrl()) &&
+            !requestDto.getImageUrl().equals(oldImageUrl)) {
+
+            try {
+                uploadService.deleteImageFromStorage(oldImageUrl);
+                log.info("기존 이미지 삭제 완료: {}", oldImageUrl);
+            } catch (Exception e) {
+                // 기존 이미지 삭제 실패 시 로그만 남기고 업데이트는 계속 진행
+                log.warn("기존 이미지 삭제 실패 (dogId: {}, oldImageUrl: {}): {}",
+                        dog.getDogId(), oldImageUrl, e.getMessage());
+            }
+        }
+
         dog.updateDogInfo(
                 StringUtils.hasText(requestDto.getName()) ? requestDto.getName() : dog.getName(),
                 breed,
@@ -29,7 +53,7 @@ public class DogUpdater {
                 requestDto.getHealthStatus() != null ? requestDto.getHealthStatus() : dog.getHealthStatus(),
                 requestDto.getDescription() != null ? requestDto.getDescription() : dog.getDescription(),
                 requestDto.getAdoptionStatus() != null ? requestDto.getAdoptionStatus() : dog.getAdoptionStatus(),
-                StringUtils.hasText(requestDto.getImageUrl()) ? requestDto.getImageUrl() : dog.getImageUrl(),
+                newImageUrl,
                 shelter
         );
     }

--- a/src/main/java/com/example/petner/domain/post/service/PostService.java
+++ b/src/main/java/com/example/petner/domain/post/service/PostService.java
@@ -9,17 +9,20 @@ import com.example.petner.domain.post.dto.response.PostDeleteResponseDto;
 import com.example.petner.domain.post.dto.request.PostUpdateRequestDto;
 import com.example.petner.domain.post.repository.PostRepository;
 import com.example.petner.domain.post.entity.Post;
+import com.example.petner.domain.upload.service.UploadService;
 import com.example.petner.global.exception.ErrorCode;
 import com.example.petner.global.exception.customException.MemberException;
 import com.example.petner.global.exception.customException.PostException;
 import com.example.petner.search.event.PostEvent;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -28,25 +31,43 @@ public class PostService {
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final UploadService uploadService;
+    private final PostUpdater postUpdater;
 
     @Transactional
     public PostResponseDto createPost(Long authorId, PostCreateRequestDto request) {
-        Member author = memberRepository.findById(authorId)
-                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+        String thumbImageUrl = request.getThumbImageUrl();
 
-        Post post = Post.builder()
-                .title(request.getTitle())
-                .content(request.getContent())
-                .thumbImageUrl(request.getThumbImageUrl())
-                .author(author)
-                .build();
+        try {
+            Member author = memberRepository.findById(authorId)
+                    .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
 
-        Post savedPost = postRepository.save(post);
+            Post post = Post.builder()
+                    .title(request.getTitle())
+                    .content(request.getContent())
+                    .thumbImageUrl(thumbImageUrl)
+                    .author(author)
+                    .build();
 
-        // OpenSearch 동기화를 위한 이벤트 발행
-        eventPublisher.publishEvent(PostEvent.created(savedPost.getPostId()));
+            Post savedPost = postRepository.save(post);
 
-        return new PostResponseDto(savedPost);
+            // OpenSearch 동기화를 위한 이벤트 발행
+            eventPublisher.publishEvent(PostEvent.created(savedPost.getPostId()));
+
+            return new PostResponseDto(savedPost);
+
+        } catch (Exception e) {
+            // Post 생성 실패 시 업로드된 이미지 삭제
+            if (thumbImageUrl != null && !thumbImageUrl.isBlank()) {
+                try {
+                    uploadService.deleteImageFromStorage(thumbImageUrl);
+                    log.info("Post 생성 실패로 인한 이미지 삭제 완료: {}", thumbImageUrl);
+                } catch (Exception deleteException) {
+                    log.warn("Post 생성 실패 후 이미지 삭제 실패: {}", thumbImageUrl, deleteException);
+                }
+            }
+            throw e; // 원래 예외를 다시 던짐
+        }
     }
 
     @Transactional
@@ -76,7 +97,8 @@ public class PostService {
             throw new PostException(ErrorCode.POST_ACCESS_DENIED);
         }
 
-        post.update(request.getTitle(), request.getContent(), request.getThumbImageUrl());
+        // 게시글 정보 업데이트 (이미지 삭제 로직 포함)
+        postUpdater.updatePost(post, request);
 
         // OpenSearch 동기화를 위한 이벤트 발행
         eventPublisher.publishEvent(PostEvent.updated(postId));
@@ -92,6 +114,17 @@ public class PostService {
         // 작성자 권한 확인
         if (!post.getAuthor().getMemberId().equals(currentUserId)) {
             throw new PostException(ErrorCode.POST_ACCESS_DENIED);
+        }
+
+        // GCP Storage에서 썸네일 이미지 삭제
+        if (post.getThumbImageUrl() != null && !post.getThumbImageUrl().isBlank()) {
+            try {
+                uploadService.deleteImageFromStorage(post.getThumbImageUrl());
+            } catch (Exception e) {
+                // 이미지 삭제 실패 시 로그는 남기지만 DB 삭제는 계속 진행
+                log.warn("게시글 삭제 중 썸네일 이미지 삭제 실패 (postId: {}, imageUrl: {}): {}",
+                        postId, post.getThumbImageUrl(), e.getMessage());
+            }
         }
 
         postRepository.delete(post);

--- a/src/main/java/com/example/petner/domain/post/service/PostUpdater.java
+++ b/src/main/java/com/example/petner/domain/post/service/PostUpdater.java
@@ -1,0 +1,45 @@
+package com.example.petner.domain.post.service;
+
+import com.example.petner.domain.post.dto.request.PostUpdateRequestDto;
+import com.example.petner.domain.post.entity.Post;
+import com.example.petner.domain.upload.service.UploadService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * 게시글 정보 업데이트를 담당하는 컴포넌트
+ * Single Responsibility Principle(SRP)을 준수하여 업데이트 로직만 담당
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PostUpdater {
+
+    private final UploadService uploadService;
+
+    /**
+     * 게시글 정보 업데이트
+     * 이미지 URL이 변경된 경우 기존 이미지 삭제 처리
+     */
+    public void updatePost(Post post, PostUpdateRequestDto requestDto) {
+        String oldThumbImageUrl = post.getThumbImageUrl();
+        String newThumbImageUrl = requestDto.getThumbImageUrl();
+
+        // 이미지 URL이 변경된 경우 기존 이미지 삭제
+        if (newThumbImageUrl != null && !newThumbImageUrl.equals(oldThumbImageUrl)) {
+            if (oldThumbImageUrl != null && !oldThumbImageUrl.isBlank()) {
+                try {
+                    uploadService.deleteImageFromStorage(oldThumbImageUrl);
+                    log.info("기존 썸네일 이미지 삭제 완료: {}", oldThumbImageUrl);
+                } catch (Exception e) {
+                    // 기존 이미지 삭제 실패 시 로그만 남기고 업데이트는 계속 진행
+                    log.warn("기존 썸네일 이미지 삭제 실패 (postId: {}, oldImageUrl: {}): {}",
+                            post.getPostId(), oldThumbImageUrl, e.getMessage());
+                }
+            }
+        }
+
+        post.update(requestDto.getTitle(), requestDto.getContent(), requestDto.getThumbImageUrl());
+    }
+}


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
데이터베이스의 `Post` 및 `Dog` 엔티티와 GCS 이미지의 라이프사이클을 동기화하는 기능을 구현했습니다.

기존에는 엔티티 정보가 수정되거나 삭제되어도 GCS에는 이전 이미지가 그대로 남아 스토리지 낭비와 데이터 불일치 문제가 있었습니다. 이번 PR을 통해 `Post`에도 GCS 이미지 관리 기능을 신규 도입하고, `Post`와 `Dog`의 수정/삭제 로직을 개선했습니다.

**주요 변경 사항**
- Create 로직: `Post` 또는 `Dog` 정보가 데이터베이스에 저장을 실패할 경우, GCS에 저장되어 있던 이미지를 삭제합니다.
- Update 로직: `Post` 또는 `Dog` 정보가 새로운 이미지로 업데이트될 경우, GCS에 저장되어 있던 기존(이전) 이미지를 자동으로 삭제합니다.
- Delete 로직: `Post` 정보가 삭제될 경우, GCS에 저장된 관련 이미지를 함께 삭제합니다.

이를 통해 불필요한 스토리지 비용을 절감하고 데이터 정합성을 확보합니다.

# 연관 이슈 및 Close 할 이슈 작성
<!--이슈 번호를 적어주세요(예시: fix #123). -->
#67

close #67

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?