### PR TITLE
[Refactor] Presigned URL 생성 시 파일 타입 검증 로직 - refactor/ddd-71

### DIFF
--- a/src/main/java/com/example/petner/domain/upload/controller/UploadController.java
+++ b/src/main/java/com/example/petner/domain/upload/controller/UploadController.java
@@ -2,6 +2,7 @@ package com.example.petner.domain.upload.controller;
 
 import com.example.petner.domain.upload.dto.response.DownloadUrlResponseDto;
 import com.example.petner.domain.upload.dto.response.UploadUrlResponseDto;
+import com.example.petner.domain.upload.service.FileValidator;
 import com.example.petner.global.annotation.SessionMember;
 import com.example.petner.global.dto.SessionUser;
 import com.example.petner.global.exception.ErrorCode;
@@ -27,6 +28,8 @@ import java.util.concurrent.TimeUnit;
 public class UploadController {
 
     private final Storage storage;
+    private final FileValidator fileValidator;
+
     @Value("${GCP_BUCKET}")
     private String bucketName;
 
@@ -36,10 +39,9 @@ public class UploadController {
             @RequestParam String fileName,
             @RequestParam(required = false) String fileType,
             @SessionMember SessionUser user) {
-        // 기본값으로 image/* 만 허용
-        if (fileType == null || fileType.isBlank() || !fileType.startsWith("image/")) {
-            throw new UploadException(ErrorCode.UPLOAD_INVALID_FILE_TYPE);
-        }
+
+        // 파일 유효성 검증
+        fileValidator.validateFile(fileName, fileType);
 
         try {
             // UUID를 파일명에 적용하여 고유한 객체명 생성

--- a/src/main/java/com/example/petner/domain/upload/service/FileValidator.java
+++ b/src/main/java/com/example/petner/domain/upload/service/FileValidator.java
@@ -1,0 +1,107 @@
+package com.example.petner.domain.upload.service;
+
+import com.example.petner.global.exception.ErrorCode;
+import com.example.petner.global.exception.customException.UploadException;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * 파일 업로드 유효성 검증을 담당하는 컴포넌트
+ * Single Responsibility Principle(SRP)을 준수하여 파일 검증 로직만 담당
+ */
+@Component
+public class FileValidator {
+
+    // 허용된 MIME 타입
+    private static final Set<String> ALLOWED_MIME_TYPES = Set.of(
+            "image/jpeg",
+            "image/jpg",
+            "image/png",
+            "image/webp"
+    );
+
+    // 허용된 파일 확장자
+    private static final Set<String> ALLOWED_EXTENSIONS = Set.of(
+            ".jpg",
+            ".jpeg",
+            ".png",
+            ".webp"
+    );
+
+    // MIME 타입과 확장자 매핑
+    private static final Map<String, Set<String>> MIME_TO_EXTENSIONS = Map.of(
+            "image/jpeg", Set.of(".jpg", ".jpeg"),
+            "image/jpg", Set.of(".jpg", ".jpeg"),
+            "image/png", Set.of(".png"),
+            "image/webp", Set.of(".webp")
+    );
+
+    /**
+     * 파일 유효성 검증
+     */
+    public void validateFile(String fileName, String fileType) {
+        validateMimeType(fileType);
+        validateFileName(fileName);
+        validateFileExtension(fileName, fileType);
+    }
+
+    /**
+     * MIME 타입 검증
+     */
+    private void validateMimeType(String fileType) {
+        if (fileType == null || fileType.isBlank()) {
+            throw new UploadException(ErrorCode.UPLOAD_INVALID_FILE_TYPE);
+        }
+
+        if (!ALLOWED_MIME_TYPES.contains(fileType.toLowerCase())) {
+            throw new UploadException(ErrorCode.UPLOAD_INVALID_FILE_TYPE);
+        }
+    }
+
+    /**
+     * 파일명 검증
+     */
+    private void validateFileName(String fileName) {
+        if (fileName == null || fileName.isBlank()) {
+            throw new UploadException(ErrorCode.UPLOAD_INVALID_FILE_TYPE);
+        }
+
+        // 위험한 문자 검증 (경로 탐색 및 시스템 파일명 공격 방지)
+        String[] dangerousChars = {"..", "/", "\\", ":", "*", "?", "\"", "<", ">", "|"};
+        for (String dangerousChar : dangerousChars) {
+            if (fileName.contains(dangerousChar)) {
+                throw new UploadException(ErrorCode.UPLOAD_INVALID_FILE_TYPE);
+            }
+        }
+    }
+
+    /**
+     * 파일 확장자와 MIME 타입 일치성 검증
+     */
+    private void validateFileExtension(String fileName, String fileType) {
+        String extension = getFileExtension(fileName).toLowerCase();
+
+        if (!ALLOWED_EXTENSIONS.contains(extension)) {
+            throw new UploadException(ErrorCode.UPLOAD_INVALID_FILE_TYPE);
+        }
+
+        // MIME 타입과 확장자 일치성 검증
+        Set<String> allowedExtensions = MIME_TO_EXTENSIONS.get(fileType.toLowerCase());
+        if (allowedExtensions == null || !allowedExtensions.contains(extension)) {
+            throw new UploadException(ErrorCode.UPLOAD_INVALID_FILE_TYPE);
+        }
+    }
+
+    /**
+     * 파일 확장자 추출
+     */
+    private String getFileExtension(String fileName) {
+        int lastDotIndex = fileName.lastIndexOf('.');
+        if (lastDotIndex == -1 || lastDotIndex == fileName.length() - 1) {
+            throw new UploadException(ErrorCode.UPLOAD_INVALID_FILE_TYPE);
+        }
+        return fileName.substring(lastDotIndex);
+    }
+}


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
Presigned URL 생성 시 파일 업로드 검증 로직을 강화하여 보안 취약점을 개선했습니다.

기존의 `startsWith("image/")` 방식은 악의적인 파일(예: SVG를 이용한 XSS)이나 MIME 타입이 조작된 파일(예: `.php` 파일을 `.jpg`로 위장) 업로드에 취약했습니다. 이번 리팩토링을 통해 다음과 같이 검증 로직을 강화했습니다.

**주요 변경 사항**
- MIME 타입 화이트리스트 적용: 허용된 이미지 타입(`image/jpeg`, `image/png` 등)만 업로드할 수 있도록 변경했습니다.
- 확장자-MIME 타입 일치 검증: 클라이언트가 보낸 파일의 확장자와 MIME 타입이 서로 일치하는지 확인하는 로직을 추가했습니다.
- 경로 조작 방지: 파일명에 `../`와 같은 문자가 포함되지 않도록 검증하여 경로 조작 공격을 방지합니다.

# 연관 이슈 및 Close 할 이슈 작성
<!--이슈 번호를 적어주세요(예시: fix #123). -->
#71

close #71

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?