### PR TITLE
[Feature] 게시글 좋아요 기능 개발 - feature/ddd-77

### DIFF
--- a/src/main/java/com/example/petner/domain/like/controller/PostLikeController.java
+++ b/src/main/java/com/example/petner/domain/like/controller/PostLikeController.java
@@ -1,0 +1,47 @@
+package com.example.petner.domain.like.controller;
+
+import com.example.petner.domain.like.dto.response.PostLikeResponseDto;
+import com.example.petner.domain.like.service.PostLikeService;
+import com.example.petner.global.annotation.SessionMember;
+import com.example.petner.global.dto.SessionUser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 게시물 좋아요 관련 API Controller
+ */
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+@Tag(name = "게시물 좋아요 (Post Likes)", description = "게시물 좋아요 관련 API")
+public class PostLikeController {
+
+    private final PostLikeService postLikeService;
+
+    @PostMapping("/posts/{postId}/like")
+    @Operation(summary = "게시물 좋아요 토글", description = "게시물에 좋아요를 추가하거나 취소합니다.")
+    @ApiResponse(responseCode = "200", description = "좋아요 처리 성공")
+    public ResponseEntity<PostLikeResponseDto> toggleLike(
+            @Parameter(description = "게시물 ID") @PathVariable Long postId,
+            @SessionMember SessionUser user) {
+
+        PostLikeResponseDto response = postLikeService.toggleLike(postId, user);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/posts/{postId}/like")
+    @Operation(summary = "게시물 좋아요 정보 조회", description = "특정 게시물의 좋아요 개수와 현재 사용자의 좋아요 여부를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "좋아요 정보 조회 성공")
+    public ResponseEntity<PostLikeResponseDto> getLikeInfo(
+            @Parameter(description = "게시물 ID") @PathVariable Long postId,
+            @SessionMember(required = false) SessionUser user) {
+
+        PostLikeResponseDto response = postLikeService.getLikeInfo(postId, user);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/example/petner/domain/like/dto/response/PostLikeResponseDto.java
+++ b/src/main/java/com/example/petner/domain/like/dto/response/PostLikeResponseDto.java
@@ -1,0 +1,24 @@
+package com.example.petner.domain.like.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "게시물 좋아요 응답")
+public class PostLikeResponseDto {
+
+    @Schema(description = "게시물 ID", example = "1")
+    private Long postId;
+
+    @Schema(description = "좋아요 개수", example = "15")
+    private Integer likeCount;
+
+    @Schema(description = "현재 사용자의 좋아요 여부", example = "true")
+    private Boolean isLiked;
+}

--- a/src/main/java/com/example/petner/domain/like/entity/PostLike.java
+++ b/src/main/java/com/example/petner/domain/like/entity/PostLike.java
@@ -1,0 +1,47 @@
+package com.example.petner.domain.like.entity;
+
+import com.example.petner.domain.member.entity.Member;
+import com.example.petner.domain.post.entity.Post;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * 게시물 좋아요 엔티티
+ * Member와 Post 간의 다대다 관계를 표현하는 중간 엔티티
+ */
+@Entity
+@Table(name = "post_likes",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "post_id"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostLike {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "like_id")
+    private Long likeId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public PostLike(Member member, Post post) {
+        this.member = member;
+        this.post = post;
+    }
+}

--- a/src/main/java/com/example/petner/domain/like/repository/PostLikeRepository.java
+++ b/src/main/java/com/example/petner/domain/like/repository/PostLikeRepository.java
@@ -1,0 +1,49 @@
+package com.example.petner.domain.like.repository;
+
+import com.example.petner.domain.like.entity.PostLike;
+import com.example.petner.domain.member.entity.Member;
+import com.example.petner.domain.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+
+    /**
+     * 특정 사용자가 특정 게시물에 좋아요를 눌렀는지 확인
+     */
+    boolean existsByMemberAndPost(Member member, Post post);
+
+    /**
+     * 특정 사용자의 특정 게시물 좋아요 조회
+     */
+    Optional<PostLike> findByMemberAndPost(Member member, Post post);
+
+    /**
+     * 특정 사용자가 좋아요한 게시물 목록 조회 (FETCH JOIN으로 N+1 해결)
+     */
+    @Query("SELECT pl.post FROM PostLike pl " +
+           "JOIN FETCH pl.post.author " +
+           "WHERE pl.member = :member " +
+           "ORDER BY pl.createdAt DESC")
+    List<Post> findLikedPostsByMember(@Param("member") Member member);
+
+    /**
+     * 특정 게시물들에 대한 사용자의 좋아요 여부를 일괄 조회 (N+1 문제 해결)
+     */
+    @Query("SELECT pl FROM PostLike pl " +
+           "JOIN FETCH pl.post " +
+           "JOIN FETCH pl.member " +
+           "WHERE pl.member = :member AND pl.post IN :posts")
+    List<PostLike> findByMemberAndPostIn(@Param("member") Member member, @Param("posts") List<Post> posts);
+
+    /**
+     * 특정 사용자의 좋아요 삭제 (좋아요 취소)
+     */
+    void deleteByMemberAndPost(Member member, Post post);
+}

--- a/src/main/java/com/example/petner/domain/like/service/PostLikeService.java
+++ b/src/main/java/com/example/petner/domain/like/service/PostLikeService.java
@@ -1,0 +1,164 @@
+package com.example.petner.domain.like.service;
+
+import com.example.petner.domain.like.dto.response.PostLikeResponseDto;
+import com.example.petner.domain.like.entity.PostLike;
+import com.example.petner.domain.like.repository.PostLikeRepository;
+import com.example.petner.domain.member.entity.Member;
+import com.example.petner.domain.post.entity.Post;
+import com.example.petner.domain.post.repository.PostRepository;
+import com.example.petner.global.dto.SessionUser;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 게시물 좋아요 서비스
+ * 좋아요 추가/취소 및 조회 기능을 제공
+ * SOLID 원칙을 준수하여 리팩토링된 버전
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostLikeService {
+
+    private final PostLikeRepository postLikeRepository;
+    private final PostLikeValidator postLikeValidator;
+    private final PostRepository postRepository;
+
+    /**
+     * 게시물 좋아요 토글 (좋아요/좋아요 취소)
+     *
+     * @param postId 게시물 ID
+     * @param user 세션 사용자 정보
+     * @return 좋아요 결과 정보
+     */
+    @Transactional
+    public PostLikeResponseDto toggleLike(Long postId, SessionUser user) {
+        Post post = postLikeValidator.validateAndGetPost(postId);
+        Member member = postLikeValidator.validateAndGetMember(user.getMemberId());
+
+        Optional<PostLike> existingLike = postLikeRepository.findByMemberAndPost(member, post);
+
+        if (existingLike.isPresent()) {
+            // 좋아요 취소
+            return unlikePost(post, member, existingLike.get());
+        } else {
+            // 좋아요 추가
+            return likePost(post, member);
+        }
+    }
+
+    /**
+     * 특정 게시물의 좋아요 정보 조회
+     *
+     * @param postId 게시물 ID
+     * @param user 세션 사용자 정보 (nullable)
+     * @return 좋아요 정보
+     */
+    public PostLikeResponseDto getLikeInfo(Long postId, SessionUser user) {
+        Post post = postLikeValidator.validateAndGetPost(postId);
+
+        boolean isLiked = false;
+        if (user != null) {
+            Member member = postLikeValidator.validateAndGetMember(user.getMemberId());
+            isLiked = postLikeRepository.existsByMemberAndPost(member, post);
+        }
+
+        return PostLikeResponseDto.builder()
+                .postId(postId)
+                .likeCount(post.getLikeCount())
+                .isLiked(isLiked)
+                .build();
+    }
+
+    /**
+     * 여러 게시물에 대한 사용자의 좋아요 상태를 일괄 조회 (N+1 문제 해결)
+     *
+     * @param posts 게시물 목록
+     * @param user 세션 사용자 정보
+     * @return 게시물 ID와 좋아요 여부 매핑
+     */
+    public Map<Long, Boolean> getLikeStatusMap(List<Post> posts, SessionUser user) {
+        if (user == null || posts.isEmpty()) {
+            return posts.stream()
+                    .collect(Collectors.toMap(Post::getPostId, post -> false));
+        }
+
+        Member member = postLikeValidator.validateAndGetMember(user.getMemberId());
+        List<PostLike> userLikes = postLikeRepository.findByMemberAndPostIn(member, posts);
+
+        Set<Long> likedPostIds = userLikes.stream()
+                .map(like -> like.getPost().getPostId())
+                .collect(Collectors.toSet());
+
+        return posts.stream()
+                .collect(Collectors.toMap(
+                        Post::getPostId,
+                        post -> likedPostIds.contains(post.getPostId())
+                ));
+    }
+
+    /**
+     * 사용자가 좋아요한 게시물 목록 조회
+     *
+     * @param user 세션 사용자 정보
+     * @return 좋아요한 게시물 목록
+     */
+    public List<Post> getLikedPostsByUser(SessionUser user) {
+        Member member = postLikeValidator.validateAndGetMember(user.getMemberId());
+        return postLikeRepository.findLikedPostsByMember(member);
+    }
+
+    /**
+     * 좋아요 추가 처리
+     */
+    @Transactional
+    protected PostLikeResponseDto likePost(Post post, Member member) {
+        PostLike postLike = PostLike.builder()
+                .post(post)
+                .member(member)
+                .build();
+
+        postLikeRepository.save(postLike);
+        postRepository.increaseLikeCount(post.getPostId());
+
+        // Post 인스턴스도 업데이트 (중요!)
+        post.increaseLikeCount();
+
+        log.info("사용자 {}가 게시물 {}에 좋아요를 눌렀습니다.", member.getMemberId(), post.getPostId());
+
+        return PostLikeResponseDto.builder()
+                .postId(post.getPostId())
+                .likeCount(post.getLikeCount())
+                .isLiked(true)
+                .build();
+    }
+
+    /**
+     * 좋아요 취소 처리
+     */
+    @Transactional
+    protected PostLikeResponseDto unlikePost(Post post, Member member, PostLike existingLike) {
+        postLikeRepository.delete(existingLike);
+        postRepository.decreaseLikeCount(post.getPostId());
+
+        // Post 인스턴스도 업데이트 (중요!)
+        post.decreaseLikeCount();
+
+        log.info("사용자 {}가 게시물 {}의 좋아요를 취소했습니다.", member.getMemberId(), post.getPostId());
+
+        return PostLikeResponseDto.builder()
+                .postId(post.getPostId())
+                .likeCount(post.getLikeCount())
+                .isLiked(false)
+                .build();
+    }
+}

--- a/src/main/java/com/example/petner/domain/like/service/PostLikeValidator.java
+++ b/src/main/java/com/example/petner/domain/like/service/PostLikeValidator.java
@@ -1,0 +1,39 @@
+package com.example.petner.domain.like.service;
+
+import com.example.petner.domain.member.entity.Member;
+import com.example.petner.domain.member.repository.MemberRepository;
+import com.example.petner.domain.post.entity.Post;
+import com.example.petner.domain.post.repository.PostRepository;
+import com.example.petner.global.exception.ErrorCode;
+import com.example.petner.global.exception.customException.MemberException;
+import com.example.petner.global.exception.customException.PostException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * 좋아요 관련 검증 로직을 담당하는 컴포넌트
+ * Single Responsibility Principle(SRP)을 준수하여 검증 로직만 담당
+ */
+@Component
+@RequiredArgsConstructor
+public class PostLikeValidator {
+
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 게시물 존재 여부 검증 및 조회
+     */
+    public Post validateAndGetPost(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
+    }
+
+    /**
+     * 회원 존재 여부 검증 및 조회
+     */
+    public Member validateAndGetMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/example/petner/domain/post/dto/response/PostResponseDto.java
+++ b/src/main/java/com/example/petner/domain/post/dto/response/PostResponseDto.java
@@ -14,6 +14,8 @@ public class PostResponseDto {
     private final String thumbImageUrl;
     private final String authorNickname;
     private final int viewCount;
+    private final int likeCount;
+    private final boolean isLiked;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
@@ -24,6 +26,21 @@ public class PostResponseDto {
         this.thumbImageUrl = post.getThumbImageUrl();
         this.authorNickname = post.getAuthor().getNickname();
         this.viewCount = post.getViewCount();
+        this.likeCount = post.getLikeCount();
+        this.isLiked = false; // 기본값, 실제 값은 Service에서 설정
+        this.createdAt = post.getCreatedAt();
+        this.updatedAt = post.getUpdatedAt();
+    }
+
+    public PostResponseDto(Post post, boolean isLiked) {
+        this.postId = post.getPostId();
+        this.title = post.getTitle();
+        this.content = post.getContent();
+        this.thumbImageUrl = post.getThumbImageUrl();
+        this.authorNickname = post.getAuthor().getNickname();
+        this.viewCount = post.getViewCount();
+        this.likeCount = post.getLikeCount();
+        this.isLiked = isLiked;
         this.createdAt = post.getCreatedAt();
         this.updatedAt = post.getUpdatedAt();
     }

--- a/src/main/java/com/example/petner/domain/post/dto/response/PostSummaryResponseDto.java
+++ b/src/main/java/com/example/petner/domain/post/dto/response/PostSummaryResponseDto.java
@@ -13,6 +13,7 @@ public class PostSummaryResponseDto {
     private final String thumbImageUrl;
     private final String authorNickname;
     private final int viewCount;
+    private final int likeCount;
     private final LocalDateTime createdAt;
 
     public PostSummaryResponseDto(Post post) {
@@ -21,6 +22,7 @@ public class PostSummaryResponseDto {
         this.thumbImageUrl = post.getThumbImageUrl();
         this.authorNickname = post.getAuthor().getNickname();
         this.viewCount = post.getViewCount();
+        this.likeCount = post.getLikeCount();
         this.createdAt = post.getCreatedAt();
     }
 }

--- a/src/main/java/com/example/petner/domain/post/entity/Post.java
+++ b/src/main/java/com/example/petner/domain/post/entity/Post.java
@@ -31,6 +31,9 @@ public class Post {
     @Column(name = "view_count", nullable = false)
     private Integer viewCount = 0;
 
+    @Column(name = "like_count", nullable = false)
+    private Integer likeCount = 0;
+
     @Column(name = "thumb_image_url", length = 500)
     private String thumbImageUrl;
 
@@ -53,6 +56,7 @@ public class Post {
         this.thumbImageUrl = thumbImageUrl;
         this.author = author;
         this.viewCount = 0;
+        this.likeCount = 0;
     }
 
     public void increaseViewCount() {
@@ -63,5 +67,15 @@ public class Post {
         this.title = title;
         this.content = content;
         this.thumbImageUrl = thumbImageUrl;
+    }
+
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decreaseLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount--;
+        }
     }
 }

--- a/src/main/java/com/example/petner/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/example/petner/domain/post/repository/PostRepository.java
@@ -5,6 +5,7 @@ import com.example.petner.domain.post.entity.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -36,4 +37,18 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("SELECT p FROM Post p JOIN FETCH p.author WHERE p.postId = :postId")
     java.util.Optional<Post> findByIdWithAuthor(@Param("postId") Long postId);
+
+    /**
+     * 게시물의 좋아요 개수 증가
+     */
+    @Modifying
+    @Query("UPDATE Post p SET p.likeCount = p.likeCount + 1 WHERE p.postId = :postId")
+    void increaseLikeCount(@Param("postId") Long postId);
+
+    /**
+     * 게시물의 좋아요 개수 감소
+     */
+    @Modifying
+    @Query("UPDATE Post p SET p.likeCount = p.likeCount - 1 WHERE p.postId = :postId AND p.likeCount > 0")
+    void decreaseLikeCount(@Param("postId") Long postId);
 }

--- a/src/main/resources/db/migration/V20250928073810__Add_like_functionality.sql
+++ b/src/main/resources/db/migration/V20250928073810__Add_like_functionality.sql
@@ -1,0 +1,28 @@
+-- V20250928073810__Add_like_functionality.sql
+-- 좋아요 기능 추가: post_likes 테이블 생성 및 posts 테이블에 like_count 컬럼 추가
+
+-- 1. 게시물 좋아요 테이블 생성
+CREATE TABLE post_likes (
+    like_id BIGSERIAL PRIMARY KEY,
+    member_id BIGINT NOT NULL,
+    post_id BIGINT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    -- 복합 유니크 제약조건: 한 사용자는 하나의 게시물에 한 번만 좋아요 가능
+    CONSTRAINT uk_post_likes_member_post UNIQUE (member_id, post_id),
+
+    -- 외래키 제약조건
+    CONSTRAINT fk_post_likes_member FOREIGN KEY (member_id) REFERENCES members(member_id) ON DELETE CASCADE,
+    CONSTRAINT fk_post_likes_post FOREIGN KEY (post_id) REFERENCES posts(post_id) ON DELETE CASCADE
+);
+
+-- 2. posts 테이블에 좋아요 개수 컬럼 추가
+ALTER TABLE posts
+ADD COLUMN like_count INTEGER NOT NULL DEFAULT 0;
+
+-- 3. 인덱스 생성 (성능 최적화)
+CREATE INDEX idx_post_likes_member_id ON post_likes(member_id);
+CREATE INDEX idx_post_likes_post_id ON post_likes(post_id);
+
+-- 4. 기존 게시물의 좋아요 개수 초기화 (0으로 설정)
+UPDATE posts SET like_count = 0 WHERE like_count IS NULL;


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
사용자가 게시글에 '좋아요'를 누르거나 취소할 수 있는 기능을 구현했습니다.

`Post`와 `Member` 간의 다대다 관계를 `PostLike`라는 중간 엔티티로 풀어내어 관리하며, `Post` 엔티티에 `likeCount` 필드를 추가하여 조회 성능을 최적화했습니다. 또한, 게시글 목록 및 상세 조회 시 N+1 문제가 발생하지 않도록 쿼리를 개선했습니다.

**주요 변경 사항**

- `PostLike` 엔티티 및 Repository 구현
- 좋아요 추가/취소를 위한 토글(Toggle) API 추가 (`POST /api/v1/posts/{postId}/like`)
- 특정 게시글의 좋아요 정보(개수, 현재 사용자 좋아요 여부)를 조회하는 API 추가 (`GET /api/v1/posts/{postId}/like`)
- `Post` 엔티티에 `likeCount` 필드 추가 및 관련 로직 구현
- `PostResponseDto`, `PostSummaryResponseDto`에 `likeCount`, `isLiked` 필드 추가
- Flyway를 이용한 DB 마이그레이션 스크립트 작성 (`post_likes` 테이블 생성, `posts` 테이블에 `like_count` 컬럼 추가)

# 연관 이슈 및 Close 할 이슈 작성

<!--이슈 번호를 적어주세요(예시: fix #123). -->
#77

close #77

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?