### PR TITLE
[Refactor] 지역 검색 로직 개선 (Member 및 Shelter 위치 통합) - refactor/ddd-82

### DIFF
--- a/src/main/java/com/example/petner/domain/dog/repository/DogRepository.java
+++ b/src/main/java/com/example/petner/domain/dog/repository/DogRepository.java
@@ -42,7 +42,7 @@ public interface DogRepository extends JpaRepository<Dog, Long> {
     List<Dog> findAllWithAssociations();
 
     /**
-     * N+1 문제 해결을 위한 페치 조인 - 개별 조회
+     * N+1 문제 해결을 위한 페치 조인 - 개별 조회 (기존 기능용)
      * Dog와 연관된 Breed, Member, Shelter를 한 번의 쿼리로 조회
      */
     @Query("SELECT d FROM Dog d " +
@@ -58,7 +58,8 @@ public interface DogRepository extends JpaRepository<Dog, Long> {
      */
     @Query("SELECT d FROM Dog d " +
            "JOIN FETCH d.breed " +
-           "JOIN FETCH d.member " +
+           "JOIN FETCH d.member m " +
+           "LEFT JOIN FETCH m.location " +
            "LEFT JOIN FETCH d.shelter s " +
            "LEFT JOIN FETCH s.location " +
            "WHERE d.dogId = :dogId AND d.deleted = false")

--- a/src/main/java/com/example/petner/global/config/IndexInitializer.java
+++ b/src/main/java/com/example/petner/global/config/IndexInitializer.java
@@ -105,12 +105,23 @@ public class IndexInitializer {
                           "type": "custom",
                           "tokenizer": "nori_tokenizer",
                           "filter": ["lowercase", "nori_part_of_speech"]
+                        },
+                        "ngram_analyzer": {
+                          "type": "custom",
+                          "tokenizer": "ngram_tokenizer",
+                          "filter": ["lowercase"]
                         }
                       },
                       "tokenizer": {
                         "nori_tokenizer": {
                           "type": "nori_tokenizer",
                           "decompound_mode": "mixed"
+                        },
+                        "ngram_tokenizer": {
+                          "type": "ngram",
+                          "min_gram": 2,
+                          "max_gram": 3,
+                          "token_chars": ["letter", "digit"]
                         }
                       }
                     }
@@ -122,7 +133,11 @@ public class IndexInitializer {
                         "type": "text",
                         "analyzer": "nori_analyzer",
                         "fields": {
-                          "keyword": {"type": "keyword"}
+                          "keyword": {"type": "keyword"},
+                          "ngram": {
+                            "type": "text",
+                            "analyzer": "ngram_analyzer"
+                          }
                         }
                       },
                       "breedName": {"type": "keyword"},
@@ -145,7 +160,9 @@ public class IndexInitializer {
                       "memberId": {"type": "long"},
                       "shelterId": {"type": "long"},
                       "shelterName": {"type": "keyword"},
-                      "location": {"type": "keyword"}
+                      "location": {"type": "keyword"},
+                      "memberLocation": {"type": "keyword"},
+                      "shelterLocation": {"type": "keyword"}
                     }
                   }
                 }

--- a/src/main/java/com/example/petner/search/document/DogDocument.java
+++ b/src/main/java/com/example/petner/search/document/DogDocument.java
@@ -38,9 +38,15 @@ public class DogDocument {
     private Long memberId;
     private Long shelterId;
     private String shelterName;
-    private String location; // shelter 위치 정보
+    private String location; // 통합 위치 정보 (기존 호환성 유지)
+    private String memberLocation; // member 위치 정보
+    private String shelterLocation; // shelter 위치 정보
 
     public static DogDocument from(Dog dog) {
+        String memberLocation = buildLocationString(dog.getMember().getLocation());
+        String shelterLocation = buildLocationString(dog.getShelter() != null ? dog.getShelter().getLocation() : null);
+        String primaryLocation = shelterLocation != null ? shelterLocation : memberLocation; // shelter 우선, 없으면 member
+
         return DogDocument.builder()
                 .id(String.valueOf(dog.getDogId()))
                 .dogId(dog.getDogId())
@@ -59,9 +65,14 @@ public class DogDocument {
                 .memberId(dog.getMember().getMemberId())
                 .shelterId(dog.getShelter() != null ? dog.getShelter().getShelterId() : null)
                 .shelterName(dog.getShelter() != null ? dog.getShelter().getName() : null)
-                .location(dog.getShelter() != null && dog.getShelter().getLocation() != null ?
-                    dog.getShelter().getLocation().getState() + " " + dog.getShelter().getLocation().getDistrict() : null)
+                .location(primaryLocation)
+                .memberLocation(memberLocation)
+                .shelterLocation(shelterLocation)
                 .build();
+    }
+
+    private static String buildLocationString(com.example.petner.domain.location.entity.Location location) {
+        return location != null ? location.getState() + " " + location.getDistrict() : null;
     }
 
     public static DogDocument from(DogSearchDto dto) {
@@ -84,6 +95,8 @@ public class DogDocument {
                 .shelterId(dto.getShelterId())
                 .shelterName(dto.getShelterName())
                 .location(dto.getLocation())
+                .memberLocation(dto.getMemberLocation())
+                .shelterLocation(dto.getShelterLocation())
                 .build();
     }
 }

--- a/src/main/java/com/example/petner/search/dto/DogSearchDto.java
+++ b/src/main/java/com/example/petner/search/dto/DogSearchDto.java
@@ -32,8 +32,14 @@ public class DogSearchDto {
     private final Long shelterId;
     private final String shelterName;
     private final String location;
+    private final String memberLocation;
+    private final String shelterLocation;
 
     public static DogSearchDto from(Dog dog) {
+        String memberLocation = buildLocationString(dog.getMember().getLocation());
+        String shelterLocation = buildLocationString(dog.getShelter() != null ? dog.getShelter().getLocation() : null);
+        String primaryLocation = shelterLocation != null ? shelterLocation : memberLocation; // shelter 우선, 없으면 member
+
         return new DogSearchDto(
                 dog.getDogId(),
                 dog.getName(),
@@ -51,8 +57,13 @@ public class DogSearchDto {
                 dog.getMember().getMemberId(),
                 dog.getShelter() != null ? dog.getShelter().getShelterId() : null,
                 dog.getShelter() != null ? dog.getShelter().getName() : null,
-                dog.getShelter() != null && dog.getShelter().getLocation() != null ?
-                    dog.getShelter().getLocation().getState() + " " + dog.getShelter().getLocation().getDistrict() : null
+                primaryLocation,
+                memberLocation,
+                shelterLocation
         );
+    }
+
+    private static String buildLocationString(com.example.petner.domain.location.entity.Location location) {
+        return location != null ? location.getState() + " " + location.getDistrict() : null;
     }
 }

--- a/src/main/java/com/example/petner/search/repository/DogSearchRepository.java
+++ b/src/main/java/com/example/petner/search/repository/DogSearchRepository.java
@@ -69,10 +69,17 @@ public class DogSearchRepository {
 
         // 키워드 검색: name과 description만 검색 대상
         if (keyword != null && !keyword.trim().isEmpty()) {
-            Query keywordQuery = Query.of(q -> q.multiMatch(m -> m
-                .query(keyword)
-                .fields("name^2", "description")
-                .analyzer("nori")
+            Query keywordQuery = Query.of(q -> q.bool(b -> b
+                .should(Query.of(sq -> sq.multiMatch(m -> m
+                    .query(keyword)
+                    .fields("name^3", "description")
+                    .analyzer("nori")
+                )))
+                .should(Query.of(sq -> sq.match(m -> m
+                    .field("name.ngram")
+                    .query(FieldValue.of(keyword))
+                )))
+                .minimumShouldMatch("1")
             ));
             boolQuery.must(keywordQuery);
         }

--- a/src/main/java/com/example/petner/search/repository/DogSearchRepository.java
+++ b/src/main/java/com/example/petner/search/repository/DogSearchRepository.java
@@ -91,7 +91,14 @@ public class DogSearchRepository {
         }
 
         if (location != null && !location.trim().isEmpty()) {
-            boolQuery.filter(Query.of(q -> q.match(m -> m.field("location").query(FieldValue.of(location)))));
+            // Member location OR Shelter location 검색 - 부분 일치로 검색
+            Query locationQuery = Query.of(q -> q.bool(b -> b
+                .should(Query.of(sq -> sq.matchPhrase(m -> m.field("memberLocation").query(location))))
+                .should(Query.of(sq -> sq.matchPhrase(m -> m.field("shelterLocation").query(location))))
+                .should(Query.of(sq -> sq.matchPhrase(m -> m.field("location").query(location)))) // 기존 호환성
+                .minimumShouldMatch("1")
+            ));
+            boolQuery.filter(locationQuery);
         }
 
         if (adoptionStatus != null) {


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
기존에 보호소(Shelter) 위치만을 기준으로 하던 강아지 지역 검색 로직을 회원(Member)의 거주 지역까지 포함하도록 개선합니다.

**주요 변경 사항**
- 통합 검색: 이제 사용자가 특정 지역으로 검색하면, 아래 두 조건 중 하나라도 만족하는 강아지가 모두 검색됩니다 (OR 조건).
  - 해당 지역에 위치한 보호소에 소속된 강아지
  - 해당 지역에 거주하는 회원이 등록한 강아지
- 검색 정확도 향상: 기존의 match 검색을 match_phrase로 변경하여, "서울시 강남구"와 같이 정확하게 일치하는 구문만 결과에 포함되도록 검색 정확도를 높입니다.
- 우선순위 적용: 검색 결과 노출 시 보호소의 위치 정보를 우선적으로 고려하고, 보호소 정보가 없는 경우 회원의 위치 정보를 사용하도록 로직을 구현합니다.
- 검색 편의성 개선: `nori` 분석기만으로는 불가능했던 부분 일치 검색을 위해 `ngram` 분석기를 추가합니다.

**검색 기능 개선 상세: nori + ngram 조합**
이번 리팩토링에서는 검색 정확도와 사용자 편의성을 모두 높이기 위해 `nori` 형태소 분석기와 `ngram` 분석기를 함께 사용하도록 개선했습니다.

**1. 기존 nori 분석기의 한계**
nori 분석기는 한국어 문법을 이해하여 "사랑이"를 의미 단위인 ["사랑", "이"] 로 정확하게 분석합니다. 하지만 이 방식은 "사랑"이라는 핵심 명사로는 검색이 잘 되지만, 사용자가 "랑이"와 같이 단어의 일부로 검색할 경우 해당 토큰이 없어 검색에 실패하는 한계가 있습니다.

**2. ngram 분석기로 부분 검색 지원**
ngram 분석기는 문법과 상관없이 단어를 설정된 글자 수(n)로 기계적으로 잘라냅니다. 예를 들어 "사랑이"를 2-gram으로 분석하면 ["사랑", "랑이"] 와 같은 부분 문자열 토큰을 생성합니다. 덕분에 사용자가 단어의 일부나 오타를 입력해도 검색 결과에 포함될 가능성이 높아집니다.

**3. 기대 효과**
nori를 통해 의미적으로 정확한 검색 결과를, ngram을 통해 오타나 약어 등에도 유연하게 대응하는 검색 환경을 구축하여 사용자 경험을 개선합니다.

# 연관 이슈 및 Close 할 이슈 작성
<!--이슈 번호를 적어주세요(예시: fix #123). -->

#82

close #82

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?