### PR TITLE
[Refactor] 게시물 삭제 로직 수정 및 '내 게시물' API 추가 - refactor/ddd-81

### DIFF
--- a/src/main/java/com/example/petner/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/petner/domain/comment/repository/CommentRepository.java
@@ -6,7 +6,9 @@ import com.example.petner.domain.post.entity.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
@@ -19,6 +21,16 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByPost(Post post);
 
     List<Comment> findByMember(Member member);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM Comment c WHERE c.post = :post AND c.parentComment IS NOT NULL")
+    void deleteRepliesByPost(@Param("post") Post post);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM Comment c WHERE c.post = :post AND c.parentComment IS NULL")
+    void deleteParentCommentsByPost(@Param("post") Post post);
 
     @Query("SELECT c FROM Comment c JOIN FETCH c.member WHERE c.post = :post AND c.parentComment IS NULL ORDER BY c.createdAt ASC")
     List<Comment> findParentCommentsByPost(@Param("post") Post post);

--- a/src/main/java/com/example/petner/domain/like/repository/PostLikeRepository.java
+++ b/src/main/java/com/example/petner/domain/like/repository/PostLikeRepository.java
@@ -46,4 +46,9 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
      * 특정 사용자의 좋아요 삭제 (좋아요 취소)
      */
     void deleteByMemberAndPost(Member member, Post post);
+
+    /**
+     * 특정 게시물의 모든 좋아요 삭제
+     */
+    void deleteByPost(Post post);
 }

--- a/src/main/java/com/example/petner/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/petner/domain/post/controller/PostController.java
@@ -76,6 +76,24 @@ public class PostController {
         return ResponseEntity.ok(response);
     }
 
+    @GetMapping("/my")
+    @Operation(summary = "내 게시물 목록 조회", description = "현재 사용자가 작성한 게시물 목록을 페이징하여 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "내 게시물 목록 조회 성공")
+    public ResponseEntity<Page<PostSummaryResponseDto>> getMyPosts(
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기", example = "10") @RequestParam(defaultValue = "10") int size,
+            @Parameter(description = "정렬 방식 (예: createdAt,desc)", example = "createdAt,desc") @RequestParam(defaultValue = "createdAt,desc") String sort,
+            @SessionMember SessionUser user) {
+
+        String[] sortParams = sort.split(",");
+        Sort.Direction direction = sortParams.length > 1 && "asc".equalsIgnoreCase(sortParams[1])
+            ? Sort.Direction.ASC : Sort.Direction.DESC;
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortParams[0]));
+        Page<PostSummaryResponseDto> response = postService.getMyPosts(user.getMemberId(), pageable);
+        return ResponseEntity.ok(response);
+    }
+
     @PatchMapping("/{postId}")
     @Operation(summary = "게시물 수정", description = "특정 게시물을 수정합니다.")
     @ApiResponse(responseCode = "200", description = "게시물 수정 성공")

--- a/src/main/java/com/example/petner/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/example/petner/domain/post/repository/PostRepository.java
@@ -38,6 +38,10 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("SELECT p FROM Post p JOIN FETCH p.author WHERE p.postId = :postId")
     java.util.Optional<Post> findByIdWithAuthor(@Param("postId") Long postId);
 
+    @Query(value = "SELECT p FROM Post p JOIN FETCH p.author WHERE p.author = :author",
+            countQuery = "SELECT count(p) FROM Post p WHERE p.author = :author")
+    Page<Post> findByAuthorWithPaging(@Param("author") Member author, Pageable pageable);
+
     /**
      * 게시물의 좋아요 개수 증가
      */

--- a/src/main/java/com/example/petner/domain/post/service/PostDeleteService.java
+++ b/src/main/java/com/example/petner/domain/post/service/PostDeleteService.java
@@ -1,0 +1,74 @@
+package com.example.petner.domain.post.service;
+
+import com.example.petner.domain.comment.repository.CommentRepository;
+import com.example.petner.domain.like.repository.PostLikeRepository;
+import com.example.petner.domain.post.dto.response.PostDeleteResponseDto;
+import com.example.petner.domain.post.entity.Post;
+import com.example.petner.domain.post.repository.PostRepository;
+import com.example.petner.domain.upload.service.UploadService;
+import com.example.petner.global.exception.ErrorCode;
+import com.example.petner.global.exception.customException.PostException;
+import com.example.petner.search.event.PostEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PostDeleteService {
+
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+    private final PostLikeRepository postLikeRepository;
+    private final UploadService uploadService;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public PostDeleteResponseDto deletePost(Long postId, Long currentUserId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
+
+        validateAuthor(post, currentUserId);
+        deleteRelatedData(post);
+        deletePostImage(post);
+        deletePostEntity(post);
+        publishDeleteEvent(postId);
+
+        return PostDeleteResponseDto.success(postId, currentUserId);
+    }
+
+    private void validateAuthor(Post post, Long currentUserId) {
+        if (!post.getAuthor().getMemberId().equals(currentUserId)) {
+            throw new PostException(ErrorCode.POST_ACCESS_DENIED);
+        }
+    }
+
+    private void deleteRelatedData(Post post) {
+        postLikeRepository.deleteByPost(post);
+        commentRepository.deleteRepliesByPost(post);  // 대댓글 먼저 삭제
+        commentRepository.flush();  // 즉시 DB에 반영
+        commentRepository.deleteParentCommentsByPost(post);  // 부모댓글 나중에 삭제
+    }
+
+    private void deletePostImage(Post post) {
+        if (post.getThumbImageUrl() != null && !post.getThumbImageUrl().isBlank()) {
+            try {
+                uploadService.deleteImageFromStorage(post.getThumbImageUrl());
+            } catch (Exception e) {
+                log.warn("게시글 삭제 중 썸네일 이미지 삭제 실패 (postId: {}, imageUrl: {}): {}",
+                        post.getPostId(), post.getThumbImageUrl(), e.getMessage());
+            }
+        }
+    }
+
+    private void deletePostEntity(Post post) {
+        postRepository.delete(post);
+    }
+
+    private void publishDeleteEvent(Long postId) {
+        eventPublisher.publishEvent(PostEvent.deleted(postId));
+    }
+}

--- a/src/main/java/com/example/petner/domain/post/service/PostService.java
+++ b/src/main/java/com/example/petner/domain/post/service/PostService.java
@@ -33,6 +33,7 @@ public class PostService {
     private final ApplicationEventPublisher eventPublisher;
     private final UploadService uploadService;
     private final PostUpdater postUpdater;
+    private final PostDeleteService postDeleteService;
 
     @Transactional
     public PostResponseDto createPost(Long authorId, PostCreateRequestDto request) {
@@ -72,7 +73,7 @@ public class PostService {
 
     @Transactional
     public PostResponseDto getPost(Long postId) {
-        Post post = postRepository.findByIdWithAuthor(postId)
+        Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
         post.increaseViewCount();
 
@@ -84,6 +85,14 @@ public class PostService {
 
     public Page<PostSummaryResponseDto> getPosts(Pageable pageable) {
         return postRepository.findAllWithAuthor(pageable)
+                .map(PostSummaryResponseDto::new);
+    }
+
+    public Page<PostSummaryResponseDto> getMyPosts(Long currentUserId, Pageable pageable) {
+        Member author = memberRepository.findById(currentUserId)
+                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+
+        return postRepository.findByAuthorWithPaging(author, pageable)
                 .map(PostSummaryResponseDto::new);
     }
 
@@ -108,30 +117,6 @@ public class PostService {
 
     @Transactional
     public PostDeleteResponseDto deletePost(Long postId, Long currentUserId) {
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
-
-        // 작성자 권한 확인
-        if (!post.getAuthor().getMemberId().equals(currentUserId)) {
-            throw new PostException(ErrorCode.POST_ACCESS_DENIED);
-        }
-
-        // GCP Storage에서 썸네일 이미지 삭제
-        if (post.getThumbImageUrl() != null && !post.getThumbImageUrl().isBlank()) {
-            try {
-                uploadService.deleteImageFromStorage(post.getThumbImageUrl());
-            } catch (Exception e) {
-                // 이미지 삭제 실패 시 로그는 남기지만 DB 삭제는 계속 진행
-                log.warn("게시글 삭제 중 썸네일 이미지 삭제 실패 (postId: {}, imageUrl: {}): {}",
-                        postId, post.getThumbImageUrl(), e.getMessage());
-            }
-        }
-
-        postRepository.delete(post);
-
-        // OpenSearch 동기화를 위한 이벤트 발행
-        eventPublisher.publishEvent(PostEvent.deleted(postId));
-
-        return PostDeleteResponseDto.success(postId, currentUserId);
+        return postDeleteService.deletePost(postId, currentUserId);
     }
 }


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
게시물(Post) 관리 기능의 삭제 로직을 개선하고, 사용자가 자신의 게시물을 조회할 수 있는 기능을 추가했습니다. 댓글이 있는 게시물 삭제 시 발생하는 무결성 오류를 해결하고, SOLID 원칙을 준수하여 코드 구조를 개선했습니다.

**주요 기능**
- 게시물 삭제 시 무결성 오류 해결
  - `PostLike`, `Comment` 순차적 hard delete 처리
  - 대댓글 → 부모댓글 순서로 안전한 삭제
  - 외래키 제약 조건 위반 방지

- 코드 구조 개선
  - `PostDeleteService` 분리로 단일 책임 원칙(SRP) 준수
  - N+1 문제 해결을 위한 쿼리 최적화
  - 불필요한 JOIN 제거

- 내 게시물 목록 조회 API
  - `GET /api/v1/posts/my` 엔드포인트 추가
  - 페이징, 정렬 기능 지원
  - 작성자 정보 포함한 효율적인 조회
 
# 연관 이슈 및 Close 할 이슈 작성
<!--이슈 번호를 적어주세요(예시: fix #123). -->
#81

close #81

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?